### PR TITLE
feat(types): introduce ReadonlySignal

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -5,6 +5,8 @@
 ---
 
 - [`RefSignal<T>`](#refsignalt)
+- [`ReadonlySignal<T>`](#readonlysignalt)
+- [`ComputedSignal<T>`](#computedsignalt)
 - [`createRefSignal<T>(initialValue, options?)`](#createrefsignalt-initialvalue-options)
 - [`SignalOptions<T>` / `Interceptor<T>` / `CANCEL`](#signaloptionst--interceptort--cancel)
 - [`useRefSignal<T>(initialValue, options?)`](#userefsignalt-initialvalue-options)
@@ -48,6 +50,31 @@ The core interface implemented by all signal objects.
 | `subscribe(listener)` | Registers a listener called with the current value on every notification. |
 | `unsubscribe(listener)` | Removes a previously registered listener. |
 | `getDebugName?()` | Returns the signal's debug name. Only present when DevTools are enabled. |
+
+---
+
+### `ReadonlySignal<T>`
+
+Read-only view of a signal — `RefSignal<T>` minus the write-side APIs (`.update()`, `.reset()`, `.notify()`, `.notifyUpdate()`). Returned by [`useRefSignalMemo`](#userefsignalmemot-factory-deps-options) and [`useRefSignalFollow`](#userefsignalfollowt-getter-deps-options) where React owns the lifetime, so no `.dispose()` is exposed.
+
+`.notify()` and `.notifyUpdate()` are excluded because they are escape hatches for direct `.current` mutation — irrelevant when the value is derived.
+
+`ReadonlySignal<T>` is the supertype of both `RefSignal<T>` and [`ComputedSignal<T>`](#computedsignalt). Use it as a parameter type whenever you only need to read or subscribe — your function will accept all three forms.
+
+```ts
+function logChanges<T>(signal: ReadonlySignal<T>) {
+  return signal.subscribe((v) => console.log(v));
+}
+logChanges(myRefSignal);      // ✓
+logChanges(myMemoSignal);      // ✓ (from useRefSignalMemo)
+logChanges(myComputedSignal);  // ✓ (from createComputedSignal)
+```
+
+---
+
+### `ComputedSignal<T>`
+
+`ReadonlySignal<T>` plus `.dispose()` — used at module scope where the lifetime is not React-managed. Returned by [`createComputedSignal`](#createcomputedsignalt-compute-deps). Calling `.dispose()` unsubscribes from dep signals and stops recomputation.
 
 ---
 
@@ -331,6 +358,8 @@ const result = useRefSignalMemo(
 - The returned signal can be subscribed to like any other signal.
 - `options` is a [`WatchOptions`](#watchoptions) — timing, filter, and `trackSignals` for dynamic-signal traversal.
 
+Returns a [`ReadonlySignal<T>`](#readonlysignalt) — read-side APIs (`.current`, `.lastUpdated`, `.subscribe`/`.unsubscribe`, `.getDebugName`) only; the write-side APIs (`.update`, `.reset`, `.notify`, `.notifyUpdate`) are hidden. The lifetime is tied to the component, so no `.dispose()` either. Pass it as a dep wherever a `ReadonlySignal` is accepted: `useRefSignalRender`, `useRefSignalEffect`, `useRefSignalMemo`, `useRefSignalFollow`, `createComputedSignal`, `watch`, `watchSignals`, and `WatchOptions.trackSignals`.
+
 ---
 
 ### `useRefSignalFollow<T>(getter, deps, options?)`
@@ -343,7 +372,7 @@ const node = useRefSignalFollow(
   () => nodes.current.get(focusedId),
   [nodes, focusedId],
 );
-// node: RefSignal<NodeData | undefined>
+// node: ReadonlySignal<NodeData | undefined>
 ```
 
 Shorthand for a [`useRefSignalMemo`](#userefsignalmemot-factory-deps-options) that reads `getter()?.current` while auto-tracking `getter()` as a dynamic signal. Use it whenever you would otherwise write a memo + matching `trackSignals` pair by hand.

--- a/docs/decision-tree.md
+++ b/docs/decision-tree.md
@@ -127,8 +127,8 @@ flowchart TD
 flowchart TD
     Q1{"Where do you need the derived value?"}
 
-    Q1 -->|Inside a React component| A["useRefSignalMemo(factory, deps, options?)\nTied to component lifetime\nDeps can mix signals and non-signals (props, state)"]
-    Q1 -->|"Outside React — module scope, context factory"| B["createComputedSignal(compute, deps)\nDeps must be RefSignals\nReturns read-only ComputedSignal with .dispose()"]
+    Q1 -->|Inside a React component| A["useRefSignalMemo(factory, deps, options?)\nTied to component lifetime\nDeps can mix signals and non-signals (props, state)\nReturns ReadonlySignal — no .dispose() (React owns cleanup)"]
+    Q1 -->|"Outside React — module scope, context factory"| B["createComputedSignal(compute, deps)\nDeps accept RefSignal / ReadonlySignal / ComputedSignal\nReturns ComputedSignal (= ReadonlySignal + .dispose())"]
 
     A --> Q3{"Need to rate-limit, filter, or follow dynamic signals?"}
     Q3 -->|Rate-limit the recompute| E["Add throttle / debounce / rAF — see Section 4"]
@@ -163,7 +163,7 @@ flowchart TD
     Q1 -->|"No — resolved through another signal's current value"| Q2
 
     Q2{"What shape do you need?"}
-    Q2 -->|"A stable RefSignal I can pass downstream as a normal dep"| B["useRefSignalFollow(() => getter(), deps)\n→ RefSignal<T | undefined>\nShorthand for the single-signal case"]
+    Q2 -->|"A stable signal I can pass downstream as a normal dep"| B["useRefSignalFollow(() => getter(), deps)\n→ ReadonlySignal<T | undefined>\nShorthand for the single-signal case"]
     Q2 -->|"React to N dynamic signals in one effect or render"| C["options.trackSignals: () => signals[]\non useRefSignalEffect / useRefSignalMemo / useRefSignalRender\n(outside React: watchSignals with the same option)"]
 
     B & C --> D["Diff-subscribed on every static-dep fire.\nRef-equal + content-equal shortcuts skip the diff when the returned array is stable."]
@@ -218,7 +218,7 @@ flowchart TD
     Q3 -->|Custom backend| G["Implement PersistStorage\n{ get, set, remove } returning Promise"]
 
     A & B & C --> Q4{"Data shape may change across releases?"}
-    Q4 -->|Yes| H["version: N\nmigrate: (storedData, storedVersion) => newData"]
+    Q4 -->|Yes| H["version: N\nmigrate: (storedData, storedVersion) => newData\nReturn null/undefined to discard storage and keep declared defaults"]
     Q4 -->|No| Q5
 
     Q5{"High-frequency updates? Want to coalesce storage writes?"}

--- a/src/hooks/useRefSignalFollow.ts
+++ b/src/hooks/useRefSignalFollow.ts
@@ -1,5 +1,5 @@
 import { DependencyList } from 'react';
-import { ReadonlySignal, RefSignal } from '../refsignal';
+import { ReadonlySignal } from '../refsignal';
 import { useRefSignalMemo } from './useRefSignalMemo';
 import type { WatchOptions } from '../timing';
 
@@ -50,7 +50,7 @@ export type FollowOptions = Omit<WatchOptions, 'trackSignals'>;
  * );
  */
 export function useRefSignalFollow<T>(
-  getter: () => RefSignal<T> | null | undefined,
+  getter: () => ReadonlySignal<T> | null | undefined,
   deps: DependencyList,
   options?: FollowOptions,
 ): ReadonlySignal<T | undefined> {

--- a/src/hooks/useRefSignalFollow.ts
+++ b/src/hooks/useRefSignalFollow.ts
@@ -1,5 +1,5 @@
 import { DependencyList } from 'react';
-import { RefSignal } from '../refsignal';
+import { ReadonlySignal, RefSignal } from '../refsignal';
 import { useRefSignalMemo } from './useRefSignalMemo';
 import type { WatchOptions } from '../timing';
 
@@ -53,7 +53,7 @@ export function useRefSignalFollow<T>(
   getter: () => RefSignal<T> | null | undefined,
   deps: DependencyList,
   options?: FollowOptions,
-): RefSignal<T | undefined> {
+): ReadonlySignal<T | undefined> {
   return useRefSignalMemo(() => getter()?.current, deps, {
     ...options,
     trackSignals: () => {

--- a/src/hooks/useRefSignalMemo.test.ts
+++ b/src/hooks/useRefSignalMemo.test.ts
@@ -21,6 +21,31 @@ describe('useRefSignalMemo', () => {
     expect(result.current.current).toBe(2);
   });
 
+  // Type-level: the returned ReadonlySignal hides every write-flavored API,
+  // including the `notify`/`notifyUpdate` escape hatches that only make sense
+  // when the caller mutated `.current` directly. This test compiling is the
+  // assertion.
+  it('returns a ReadonlySignal that hides write-side APIs (compile-time check)', () => {
+    const { result } = renderHook(() => {
+      const signal = useRefSignal(1);
+      const memo = useRefSignalMemo(() => signal.current * 2, [signal]);
+
+      // @ts-expect-error — `update` is not exposed on ReadonlySignal
+      void memo.update;
+      // @ts-expect-error — `reset` is not exposed on ReadonlySignal
+      void memo.reset;
+      // @ts-expect-error — `notify` is not exposed on ReadonlySignal
+      void memo.notify;
+      // @ts-expect-error — `notifyUpdate` is not exposed on ReadonlySignal
+      void memo.notifyUpdate;
+
+      return memo;
+    });
+
+    expect(typeof result.current.current).toBe('number');
+    expect(typeof result.current.subscribe).toBe('function');
+  });
+
   it('should update value when signal dep changes', () => {
     const factory = jest.fn(() => 2);
 

--- a/src/hooks/useRefSignalMemo.ts
+++ b/src/hooks/useRefSignalMemo.ts
@@ -1,5 +1,5 @@
 import { DependencyList, useEffect, useMemo, useRef } from 'react';
-import { RefSignal } from '../refsignal';
+import { ReadonlySignal } from '../refsignal';
 import { useRefSignal } from './useRefSignal';
 import { watchSignals } from '../watchSignals';
 import { useWatchArgs } from './useWatchArgs';
@@ -45,22 +45,22 @@ export function useRefSignalMemo<T>(
   factory: () => T,
   deps: DependencyList,
   options?: WatchOptions,
-): RefSignal<T>;
+): ReadonlySignal<T>;
 export function useRefSignalMemo<T>(
   factory: () => T | null,
   deps: DependencyList,
   options?: WatchOptions,
-): RefSignal<T | null>;
+): ReadonlySignal<T | null>;
 export function useRefSignalMemo<T>(
   factory: () => T | undefined,
   deps: DependencyList,
   options?: WatchOptions,
-): RefSignal<T | undefined>;
+): ReadonlySignal<T | undefined>;
 export function useRefSignalMemo<T>(
   factory: () => T | null | undefined,
   deps: DependencyList,
   options?: WatchOptions,
-): RefSignal<T | null | undefined> {
+): ReadonlySignal<T | null | undefined> {
   // Handles non-signal deps: React re-renders when state/props in deps change,
   // useMemo recomputes, and we sync the signal below — no extra factory() call needed.
   const memo = useMemo(factory, deps); // eslint-disable-line react-hooks/exhaustive-deps -- deps forwarded from caller

--- a/src/hooks/useRefSignalRender.ts
+++ b/src/hooks/useRefSignalRender.ts
@@ -1,5 +1,5 @@
 import { useCallback, useReducer, useRef, useSyncExternalStore } from 'react';
-import { RefSignal } from '../refsignal';
+import { ReadonlySignal } from '../refsignal';
 import { watchSignals, WatchHandle } from '../watchSignals';
 import { useWatchArgs } from './useWatchArgs';
 import type { WatchOptions } from '../timing';
@@ -49,7 +49,7 @@ import type { WatchOptions } from '../timing';
  */
 export function useRefSignalRender(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  deps: RefSignal<any>[],
+  deps: ReadonlySignal<any>[],
   callbackOrOptions?: (() => boolean) | WatchOptions,
 ): () => void {
   const [, forceUpdate] = useReducer((x: number) => x + 1, 0);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ export * from './hooks/useRefSignalFollow';
 export type {
   Listener,
   RefSignal,
+  ReadonlySignal,
+  ComputedSignal,
   SignalOptions,
   Interceptor,
   DevToolsAdapter,
@@ -20,7 +22,6 @@ export {
   createComputedSignal,
   watch,
 } from './refsignal';
-export type { ComputedSignal } from './refsignal';
 export {
   createRefSignalContext,
   createRefSignalContextHook,

--- a/src/refsignal.ts
+++ b/src/refsignal.ts
@@ -259,11 +259,27 @@ export function createRefSignal<T = unknown>(
 }
 
 /**
- * A read-only derived signal. Exposes subscription and current value but not
- * `.update()` or `.reset()`. Call `.dispose()` to stop tracking dep signals.
- * Returned by {@link createComputedSignal}.
+ * A read-only signal. Exposes subscription and current value but not
+ * `.update()`, `.reset()`, `.notify()`, or `.notifyUpdate()`. Returned by
+ * {@link useRefSignalMemo} (where React owns the lifetime — no `dispose`
+ * is exposed).
+ *
+ * Both `notify` and `notifyUpdate` are escape hatches for direct `.current`
+ * mutation, which doesn't apply when the value is derived. Supertype of
+ * both {@link RefSignal} and {@link ComputedSignal}: anything that accepts
+ * `ReadonlySignal<T>` accepts the read-write or computed forms too.
  */
-export type ComputedSignal<T> = Omit<RefSignal<T>, 'update' | 'reset'> & {
+export type ReadonlySignal<T> = Omit<
+  RefSignal<T>,
+  'update' | 'reset' | 'notify' | 'notifyUpdate'
+>;
+
+/**
+ * A read-only derived signal with a managed lifetime. Adds `.dispose()` to
+ * {@link ReadonlySignal} so callers can stop tracking dep signals when the
+ * computed value is no longer needed. Returned by {@link createComputedSignal}.
+ */
+export type ComputedSignal<T> = ReadonlySignal<T> & {
   readonly dispose: () => void;
 };
 

--- a/src/refsignal.ts
+++ b/src/refsignal.ts
@@ -142,7 +142,7 @@ export function isRefSignal<T = unknown>(obj: unknown): obj is RefSignal<T> {
 }
 
 export function subscribe<T>(
-  signal: RefSignal<T>,
+  signal: ReadonlySignal<T>,
   listener: Listener<T>,
 ): void {
   if (!listenersMap.has(signal)) {
@@ -152,7 +152,7 @@ export function subscribe<T>(
 }
 
 export function unsubscribe<T>(
-  signal: RefSignal<T>,
+  signal: ReadonlySignal<T>,
   listener: Listener<T>,
 ): void {
   const listeners = listenersMap.get(signal);
@@ -302,7 +302,7 @@ export type ComputedSignal<T> = ReadonlySignal<T> & {
 export function createComputedSignal<T>(
   compute: () => T,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  deps: RefSignal<any>[],
+  deps: ReadonlySignal<any>[],
 ): ComputedSignal<T> {
   const signal = createRefSignal(compute());
   const recompute = () => {
@@ -342,7 +342,7 @@ export function createComputedSignal<T>(
  * const stop = watch(score, (v) => log(v), { filter: () => score.current > 0 });
  */
 export function watch<T>(
-  signal: RefSignal<T>,
+  signal: ReadonlySignal<T>,
   listener: Listener<T>,
   // `trackSignals` is excluded here — `watch()` is single-signal and cannot
   // express "fire my value-delivering listener when a different signal updates"

--- a/src/timing.ts
+++ b/src/timing.ts
@@ -5,7 +5,7 @@
  */
 
 // Type-only import — avoids a runtime circular dep with `refsignal.ts`.
-import type { RefSignal } from './refsignal';
+import type { ReadonlySignal } from './refsignal';
 
 /**
  * Discriminated union of mutually exclusive timing strategies.
@@ -53,7 +53,7 @@ export interface TimingWrapper {
 export type WatchOptions = TimingOptions & {
   filter?: () => boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches `createComputedSignal` / `batch` signal-array conventions
-  trackSignals?: () => ReadonlyArray<RefSignal<any>>;
+  trackSignals?: () => ReadonlyArray<ReadonlySignal<any>>;
 };
 
 /**

--- a/src/watchSignals.ts
+++ b/src/watchSignals.ts
@@ -13,7 +13,7 @@
  * See `WatchOptions` in `./timing` for option semantics.
  */
 
-import { isRefSignal, type RefSignal } from './refsignal';
+import { isRefSignal, type ReadonlySignal } from './refsignal';
 import {
   applyTimingOptions,
   type TimingOptions,
@@ -37,7 +37,7 @@ export interface WatchHandle {
    * static and dynamic deps.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  trackedSignals(): RefSignal<any>[];
+  trackedSignals(): ReadonlySignal<any>[];
 }
 
 /**
@@ -105,9 +105,9 @@ export function watchSignals(
 
   let reconcileNeeded = false;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches `createComputedSignal` / `batch` signal-array conventions
-  let tracked: Set<RefSignal<any>> = new Set();
+  let tracked: Set<ReadonlySignal<any>> = new Set();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let lastTrackedResult: ReadonlyArray<RefSignal<any>> | undefined;
+  let lastTrackedResult: ReadonlyArray<ReadonlySignal<any>> | undefined;
   let disposed = false;
 
   const reconcile = () => {


### PR DESCRIPTION
## Summary

Refactors the signal type hierarchy so hook-scoped derived signals carry an honest type. Origin: real-world friction surfaced by carecare3's conversations-context migration (cross-tab broadcast + persist), where typing a `useRefSignalMemo` result as `ComputedSignal<T>` produced a TS error about a missing `dispose` — docs and runtime disagreed.

## What changes

New shared base type: `ReadonlySignal<T>` — `RefSignal<T>` minus the write-side APIs (`update`, `reset`, `notify`, `notifyUpdate`). `ComputedSignal<T>` is now `ReadonlySignal<T> & { dispose }`, so module-scope and hook-scope derived signals share an honest base.

- `useRefSignalMemo` / `useRefSignalFollow` now return `ReadonlySignal<T>` instead of `RefSignal<T>`. No `dispose` is exposed (React owns the lifetime).
- Read-side APIs (`subscribe`, `unsubscribe`, `watch`, `useRefSignalRender` deps, `createComputedSignal` deps, `useRefSignalFollow.getter`, `WatchHandle.trackedSignals`, `WatchOptions.trackSignals`) widened to accept `ReadonlySignal`. `RefSignal` and `ComputedSignal` both satisfy it, so all three forms flow through the read-side surface interchangeably.
- Side effect: a pre-existing latent issue is fixed — `ComputedSignal` could not be passed to `useRefSignalRender` or `createComputedSignal` as a dep without a cast, because it isn't a subtype of `RefSignal`. Now it works directly.

No runtime changes — purely type-level.

## Soft-breaking

Callers who typed a memo result as `RefSignal<T>` and called `.update()`/`.reset()`/`.notify()`/`.notifyUpdate()` on it will now get a TS error. The right fix is to switch the type to `ReadonlySignal<T>` (or remove the mutation, which was working against the abstraction).

## Commits

1. `feat(types): introduce ReadonlySignal` — type definitions + `useRefSignalMemo` / `useRefSignalFollow` return type changes + regression test.
2. `refactor(types): widen read-only consumers to ReadonlySignal` — every read-side API parameter widened.
3. `docs(api): document ReadonlySignal and updated signatures` — new `api.md` sections, TOC, decision-tree update.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` — 458/458 passing (one new compile-time regression test asserting `update`/`reset`/`notify`/`notifyUpdate` are not exposed on the memo result via `@ts-expect-error`)
- [x] `npm run build`