### PR TITLE
docs: bundle docs in package and surface decision tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# AI agent guide
+
+This file is for AI coding tools (Claude Code, Cursor, Windsurf, Copilot, GitHub Models, etc.) generating code that uses `react-refsignal`. Human contributors: see [README.md](README.md) and [docs/](docs/).
+
+## Read first
+
+When generating code with this library, consult these docs in order:
+
+1. **[docs/decision-tree.md](docs/decision-tree.md)** — flowcharts for picking the right API: signal creation, derived values, batching, context, persistence, cross-tab broadcast. **The library is designed around explicit choices; the decision tree encodes them.**
+2. **[docs/patterns.md](docs/patterns.md)** — full worked examples for non-trivial compositions, including:
+   - The sibling-leaf pattern for data hooks (RTK Query / SWR / Apollo / TanStack Query) inside a Provider.
+   - The cross-tab notification badge recipe (`broadcast` + `persist` + leader-only fetcher).
+3. **[docs/api.md](docs/api.md)** — the full type reference. Cross-references back to the decision tree.
+
+## Doc freshness
+
+The `docs/` folder bundled in this package is a snapshot from the publish point of `react-refsignal@<version>` (see `package.json`). It is authoritative for the installed version — examples and APIs match exactly.
+
+For docs added or revised between releases, the canonical location is **https://github.com/jav974/react-refsignal/tree/main/docs**. Consult it only when:
+
+- The local docs don't cover a feature the user is asking about (it may have been added since release).
+- A pattern or recipe seems incomplete or out of date.
+- The user explicitly references a doc not present locally.
+
+For everything else, prefer the local copy — it matches the installed types exactly.
+
+## Contract worth knowing
+
+- **`RefSignal<T>`** — read + write. Created by `createRefSignal` / `useRefSignal`.
+- **`ReadonlySignal<T>`** — read-only view. Returned by `useRefSignalMemo` / `useRefSignalFollow`. Supertype of the other two — accept this as a parameter type when you only read.
+- **`ComputedSignal<T>`** — read-only + `.dispose()`. Returned by `createComputedSignal` (module scope only).
+
+The lib favors **explicit re-render opt-in**. Components do not re-render on signal changes unless they call `useRefSignalRender([deps])` or read `unwrap: true` from a context hook with `renderOn`. Never assume a signal `.update()` triggers a render — wire `useRefSignalRender` (or the unwrap form) explicitly.
+
+## When generating Providers
+
+- Construct signals once at the top with `useRefSignal` (stable for component lifetime).
+- Group them into a stable store with `useMemo(() => ({ ... }), [])`.
+- Never put a re-rendering data hook (RTK Query, SWR, Apollo) directly in the Provider body — it re-renders the host on every poll. Use the **sibling-leaf pattern** documented in `docs/patterns.md`.
+
+## When composing broadcast + persist
+
+- For "one tab fetches, all tabs see it, last-known value persisted" use cases, follow the cross-tab notification badge recipe in `docs/patterns.md` exactly. The composition order matters (broadcast wraps persist; leader-only writes via `filter: isBroadcaster.current`).
+
+## Imports
+
+The package has subpath exports — import from the right one:
+
+```ts
+import { createRefSignal, useRefSignal, ... } from 'react-refsignal';
+import { broadcast, useBroadcast } from 'react-refsignal/broadcast';
+import { persist, usePersist } from 'react-refsignal/persist';
+```
+
+Importing the broadcast or persist subpath is what activates the corresponding signal-level option (`createRefSignal(0, { broadcast: 'channel' })` is a no-op until `react-refsignal/broadcast` is imported somewhere in the app).
+
+## Styles to avoid
+
+- **Don't call `.update()` / `.reset()` / `.notify()` on a `ReadonlySignal`** (e.g. a memo result). The type system rejects it; the operation fights the abstraction.
+- **Don't put `useGetXQuery()` inside the Provider body.** Use the sibling-leaf pattern.
+- **Don't subscribe with bare `signal.subscribe(fn)` inside a component.** Use `useRefSignalEffect` (cleanup is automatic) or `watch(signal, fn)` (returns a cleanup function for non-React code).
+- **Don't widen the type from `ReadonlySignal` back to `RefSignal` to mutate a memo result.** That mutation is overwritten on the next dep change.

--- a/README.md
+++ b/README.md
@@ -91,13 +91,15 @@ The canvas redraws at every frame via `useRefSignalEffect` — React's render cy
 
 ## Docs
 
-- [Concepts](docs/concepts.md) — signals, notify vs notifyUpdate, effect vs render, signal lifetime
-- [API Reference](docs/api.md) — full API with examples for every hook and function
-- [Patterns](docs/patterns.md) — draggable graphs, signal stores, collections, batching, high-frequency consumers, filtered renders
-- [Imperative renderers](docs/imperative-renderers.md) — Canvas / Pixi / WebGL / audio driven by signals, bypassing React reconciliation
-- [Cross-tab Broadcast](docs/broadcast.md) — sync signals across tabs with `react-refsignal/broadcast`
-- [Persist](docs/persist.md) — persist signals across page loads with `react-refsignal/persist`
-- [Decision Tree](docs/decision-tree.md) — pick the right API for any scenario
+- **[Decision Tree](docs/decision-tree.md)** — start here. Picks the right API for any scenario (signal creation, derived values, persistence, broadcast, context, batching). Useful as a navigation index for humans and as a generation reference for AI tools.
+- [Patterns](docs/patterns.md) — full worked examples: draggable graphs, signal stores, collections, batching, high-frequency consumers, filtered renders, the sibling-leaf pattern for data hooks, and the cross-tab notification badge recipe.
+- [API Reference](docs/api.md) — every hook and function with examples.
+- [Concepts](docs/concepts.md) — signals, notify vs notifyUpdate, effect vs render, signal lifetime.
+- [Imperative renderers](docs/imperative-renderers.md) — Canvas / Pixi / WebGL / audio driven by signals, bypassing React reconciliation.
+- [Cross-tab Broadcast](docs/broadcast.md) — sync signals across tabs with `react-refsignal/broadcast`.
+- [Persist](docs/persist.md) — persist signals across page loads with `react-refsignal/persist`.
+
+The full `docs/` folder is bundled with the npm package — installed at `node_modules/react-refsignal/docs/`. AI coding tools and IDEs can read it directly without fetching from GitHub.
 
 ## Concepts
 

--- a/package.json
+++ b/package.json
@@ -82,7 +82,11 @@
     "react-dom": ">=18.0.0"
   },
   "files": [
-    "dist"
+    "dist",
+    "docs",
+    "README.md",
+    "LICENSE",
+    "AGENTS.md"
   ],
   "size-limit": [
     {

--- a/src/broadcast/broadcast.ts
+++ b/src/broadcast/broadcast.ts
@@ -265,6 +265,8 @@ export function setupBroadcast<TStore extends object>(
 /**
  * Wraps a signal store factory to sync state across browser tabs/windows.
  *
+ * @see [Decision Tree §10 — Cross-tab Broadcast](https://github.com/jav974/react-refsignal/blob/main/docs/decision-tree.md#10-cross-tab-broadcast)
+ *
  * Returns a new factory — pass it to `createRefSignalContext` just like the original.
  * Subscriptions live for the app lifetime (factory-level singleton).
  * Use `useBroadcast` instead when the Provider mounts and unmounts during the session.

--- a/src/broadcast/useBroadcast.ts
+++ b/src/broadcast/useBroadcast.ts
@@ -8,6 +8,8 @@ import { setupBroadcast } from './broadcast';
  * Hook variant of `broadcast` — sets up cross-tab sync inside a React Provider.
  * Properly tears down on unmount (closes transport, sends bye in one-to-many mode).
  *
+ * @see [Decision Tree §10 — Cross-tab Broadcast](https://github.com/jav974/react-refsignal/blob/main/docs/decision-tree.md#10-cross-tab-broadcast)
+ *
  * Returns `{ isBroadcaster }`:
  * - `isBroadcaster` — a `RefSignal<boolean>` that is `true` when this tab is currently
  *   sending updates. Always `true` in `many-to-many` mode. In `one-to-many` mode starts

--- a/src/context/createRefSignalContext.ts
+++ b/src/context/createRefSignalContext.ts
@@ -54,6 +54,8 @@ export const ALL = 'all' as const;
  * without generating a Provider component. Use this when you need to write your
  * own Provider body (custom effects, props, external subscriptions, etc.).
  *
+ * @see [Decision Tree §8 — Context / Shared State](https://github.com/jav974/react-refsignal/blob/main/docs/decision-tree.md#8-context--shared-state)
+ *
  * The returned hook supports the same `renderOn`, `unwrap`, and timing options
  * as the hook returned by {@link createRefSignalContext}.
  *
@@ -117,6 +119,8 @@ export function createRefSignalContextHook<TStore extends object>(
 
 /**
  * Creates a named React context optimized for signal stores.
+ *
+ * @see [Decision Tree §8 — Context / Shared State](https://github.com/jav974/react-refsignal/blob/main/docs/decision-tree.md#8-context--shared-state)
  *
  * Builds on {@link createRefSignalContextHook} and adds explicit per-call tracking:
  * components opt into re-renders by naming the signals they care about.

--- a/src/hooks/useRefSignal.ts
+++ b/src/hooks/useRefSignal.ts
@@ -10,6 +10,8 @@ import {
 /**
  * React hook for creating a mutable signal-like ref with subscription support.
  *
+ * @see [Decision Tree §1 — Signal Creation](https://github.com/jav974/react-refsignal/blob/main/docs/decision-tree.md#1-signal-creation)
+ *
  * This hook returns a {@link RefSignal} object that holds a mutable value in `.current`
  * and provides methods to subscribe to changes, update the value, and notify listeners.
  *

--- a/src/hooks/useRefSignalEffect.ts
+++ b/src/hooks/useRefSignalEffect.ts
@@ -18,6 +18,8 @@ export type EffectOptions = WatchOptions & {
 /**
  * React hook for running an effect when one or more RefSignal values change.
  *
+ * @see [Decision Tree §3 — Reacting to Changes](https://github.com/jav974/react-refsignal/blob/main/docs/decision-tree.md#3-reacting-to-changes)
+ *
  * This hook is similar to React's {@link useEffect}, but it tracks changes to the `.current` value
  * of each provided RefSignal dependency and runs the effect whenever any of them updates.
  *

--- a/src/hooks/useRefSignalFollow.ts
+++ b/src/hooks/useRefSignalFollow.ts
@@ -12,10 +12,13 @@ export type FollowOptions = Omit<WatchOptions, 'trackSignals'>;
 
 /**
  * React hook that produces a stable {@link RefSignal} whose value tracks
- * another signal resolved dynamically through `getter`. The inner signal's
- * **identity** is allowed to change over time — whenever any signal in `deps`
- * fires, the hook re-evaluates `getter`, unsubscribes from the previous
- * inner signal, and subscribes to the new one.
+ * another signal resolved dynamically through `getter`.
+ *
+ * @see [Decision Tree §7 — Dynamic Signal Identity](https://github.com/jav974/react-refsignal/blob/main/docs/decision-tree.md#7-dynamic-signal-identity)
+ *
+ * The inner signal's **identity** is allowed to change over time — whenever
+ * any signal in `deps` fires, the hook re-evaluates `getter`, unsubscribes
+ * from the previous inner signal, and subscribes to the new one.
  *
  * This is shorthand for a {@link useRefSignalMemo} that reads
  * `getter()?.current` while tracking `getter()` as a dynamic signal. Use it

--- a/src/hooks/useRefSignalMemo.ts
+++ b/src/hooks/useRefSignalMemo.ts
@@ -8,6 +8,8 @@ import type { WatchOptions } from '../timing';
 /**
  * React hook for creating a memoized {@link RefSignal} whose value is derived from a factory function and dependencies.
  *
+ * @see [Decision Tree §6 — Derived Values](https://github.com/jav974/react-refsignal/blob/main/docs/decision-tree.md#6-derived-values)
+ *
  * This hook combines the behavior of {@link useMemo} and {@link useRefSignal}:
  * - The signal's value is initialized and updated using the provided factory function.
  * - The factory is re-evaluated whenever any value in the dependency list changes, and the signal is updated.

--- a/src/hooks/useRefSignalRender.ts
+++ b/src/hooks/useRefSignalRender.ts
@@ -7,6 +7,8 @@ import type { WatchOptions } from '../timing';
 /**
  * React hook that forces a component to re-render whenever one or more {@link RefSignal} dependencies update.
  *
+ * @see [Decision Tree §3 — Reacting to Changes](https://github.com/jav974/react-refsignal/blob/main/docs/decision-tree.md#3-reacting-to-changes)
+ *
  * Use this hook to automatically trigger a re-render of your component when the value of any provided RefSignal changes.
  * This is useful when you want your component to reflect the latest signal values in its render output.
  *

--- a/src/persist/persist.ts
+++ b/src/persist/persist.ts
@@ -270,6 +270,8 @@ export function setupPersist<TStore extends object>(
 /**
  * Wraps a signal store factory to persist state to storage across page loads.
  *
+ * @see [Decision Tree §9 — Persistence](https://github.com/jav974/react-refsignal/blob/main/docs/decision-tree.md#9-persistence)
+ *
  * Returns a new factory — pass it to `createRefSignalContext` just like the original.
  * Subscriptions live for the app lifetime (factory-level singleton).
  * Use `usePersist` instead when the Provider mounts and unmounts during the session.

--- a/src/persist/usePersist.ts
+++ b/src/persist/usePersist.ts
@@ -10,6 +10,8 @@ const noopAsync = async () => {};
  * Hook variant of `persist` — sets up storage persistence inside a React Provider.
  * Properly tears down on unmount (unsubscribes from signal updates).
  *
+ * @see [Decision Tree §9 — Persistence](https://github.com/jav974/react-refsignal/blob/main/docs/decision-tree.md#9-persistence)
+ *
  * Returns `{ isHydrated, flush, clear }`:
  * - `isHydrated` — a `RefSignal<boolean>` that becomes `true` once hydration completes.
  *   Use it to gate rendering until stored values are loaded.

--- a/src/refsignal.ts
+++ b/src/refsignal.ts
@@ -205,6 +205,14 @@ export function update<T>(signal: RefSignal<T>, value: T) {
   }
 }
 
+/**
+ * Creates a signal outside React — at module scope, in a context factory, or in any non-component code.
+ *
+ * @see [Decision Tree §1 — Signal Creation](https://github.com/jav974/react-refsignal/blob/main/docs/decision-tree.md#1-signal-creation)
+ *
+ * Returns a {@link RefSignal} with `.current`, `.update()`, `.reset()`, `.subscribe()`, and notification methods.
+ * Inside a React component, prefer {@link useRefSignal} so the signal's lifetime is tied to the component.
+ */
 export function createRefSignal<T = unknown>(
   initialValue: T,
   options?: string | SignalOptions<T>,
@@ -286,6 +294,9 @@ export type ComputedSignal<T> = ReadonlySignal<T> & {
 /**
  * Creates a derived signal whose value is recomputed whenever any dep signal updates.
  *
+ * @see [Decision Tree §6 — Derived Values](https://github.com/jav974/react-refsignal/blob/main/docs/decision-tree.md#6-derived-values)
+ *
+ *
  * The computed signal is read-only — calling `.update()` or `.reset()` is not exposed.
  * The computation stays live as long as any dep signal is alive.
  *
@@ -320,6 +331,9 @@ export function createComputedSignal<T>(
 
 /**
  * Subscribes a listener to a signal and returns a cleanup function.
+ *
+ * @see [Decision Tree §3 — Reacting to Changes](https://github.com/jav974/react-refsignal/blob/main/docs/decision-tree.md#3-reacting-to-changes)
+ *
  *
  * Mirrors the `useEffect` return pattern for non-React contexts — no need to
  * hold a reference to the listener just to unsubscribe later.
@@ -378,6 +392,9 @@ export function watch<T>(
 
 /**
  * Batch multiple signal updates and defer notifications until the callback completes.
+ *
+ * @see [Decision Tree §5 — Batching](https://github.com/jav974/react-refsignal/blob/main/docs/decision-tree.md#5-batching)
+ *
  *
  * **Auto-inference mode** (no deps parameter):
  * - Automatically tracks signals updated via `.update()`

--- a/src/store/createRefSignalStore.ts
+++ b/src/store/createRefSignalStore.ts
@@ -1,6 +1,8 @@
 /**
  * Creates a module-scope signal store singleton.
  *
+ * @see [Decision Tree §8 — Context / Shared State](https://github.com/jav974/react-refsignal/blob/main/docs/decision-tree.md#8-context--shared-state)
+ *
  * Calls `factory()` once immediately — the returned store lives for the
  * application's lifetime. Use {@link useRefSignalStore} to connect the store
  * to React components with opt-in re-renders, timing, and value unwrapping.

--- a/src/store/useRefSignalStore.ts
+++ b/src/store/useRefSignalStore.ts
@@ -86,6 +86,8 @@ const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
  * Connects a signal store to a React component — with opt-in re-renders,
  * timing options, filtering, and optional value unwrapping.
  *
+ * @see [Decision Tree §8 — Context / Shared State](https://github.com/jav974/react-refsignal/blob/main/docs/decision-tree.md#8-context--shared-state)
+ *
  * The store can come from {@link createRefSignalStore} (module-scope singleton),
  * from a React context via `useContext`, or from any other source.
  *

--- a/src/watchSignals.ts
+++ b/src/watchSignals.ts
@@ -45,6 +45,9 @@ export interface WatchHandle {
  * and `options.trackSignals` (dynamic). Returns a handle whose `dispose()`
  * tears down the subscription.
  *
+ * @see [Decision Tree §3 — Reacting to Changes](https://github.com/jav974/react-refsignal/blob/main/docs/decision-tree.md#3-reacting-to-changes)
+ * @see [Decision Tree §7 — Dynamic Signal Identity](https://github.com/jav974/react-refsignal/blob/main/docs/decision-tree.md#7-dynamic-signal-identity)
+ *
  * # Static vs dynamic
  *
  * - **Static**: any RefSignal inside `deps`. Subscribed at setup. Their


### PR DESCRIPTION
## Summary

Makes the library's architecture documentation discoverable to AI coding tools (Cursor, Claude Code, Copilot, Windsurf, etc.) and IDEs.

- **Bundles `docs/` in the npm package.** AI tools and IDEs that read `node_modules/react-refsignal/` now see the full doc set locally — no GitHub fetch required. Bundle size on bundlephobia unchanged (markdown is never imported); install size grows by ~50 KB unzipped.
- **Promotes the Decision Tree as the navigation entry point** in the README's Docs section.
- **Adds `@see` JSDoc cross-references** from every main public API to the relevant Decision Tree section. Surfaces in IDE tooltips via `dist/index.d.ts` and in any AI tool that reads JSDoc.
- **Adds `AGENTS.md`** at the repo root as a short pointer file for AI agents — names the type hierarchy (RefSignal / ReadonlySignal / ComputedSignal), points to `docs/decision-tree.md` and `docs/patterns.md`, and lists the patterns to avoid (mutating ReadonlySignal, data hooks in Provider body, bare subscribes, etc.).

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` — no source semantics changed (JSDoc-only edits to `src/`)
- [x] `npm run build` — `dist/index.d.ts` includes the new `@see` lines