### PR TITLE
Type coherence: dispose, ownership marker, readonly tightening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,9 +26,10 @@ For everything else, prefer the local copy — it matches the installed types ex
 
 ## Contract worth knowing
 
-- **`RefSignal<T>`** — read + write. Created by `createRefSignal` / `useRefSignal`.
-- **`ReadonlySignal<T>`** — read-only view. Returned by `useRefSignalMemo` / `useRefSignalFollow`. Supertype of the other two — accept this as a parameter type when you only read.
-- **`ComputedSignal<T>`** — read-only + `.dispose()`. Returned by `createComputedSignal` (module scope only).
+- **`RefSignal<T>`** — read + write. The universal contract; use as a function parameter type when you need to read and write. `createRefSignal` returns `RefSignal<T> & { dispose: () => void }` (you own the cleanup); `useRefSignal` returns plain `RefSignal<T>` (React owns it).
+- **`ReadonlyRefSignal<T>`** — read-only view. Returned by `useRefSignalMemo` / `useRefSignalFollow`. Supertype of `RefSignal<T>` — accept this as a parameter type when you only read.
+- **`createComputedRefSignal`** returns `ReadonlyRefSignal<T> & { dispose: () => void }` (module-scope, you own it). `ReadonlySignal<T>` and `ComputedSignal<T>` exist as deprecated aliases.
+- **Ownership rule** — if a signal value's type carries `.dispose()`, you own it. Function parameters take the universal `RefSignal` / `ReadonlyRefSignal` (no dispose) so consumers can't accidentally tear down a signal they don't own.
 
 The lib favors **explicit re-render opt-in**. Components do not re-render on signal changes unless they call `useRefSignalRender([deps])` or read `unwrap: true` from a context hook with `renderOn`. Never assume a signal `.update()` triggers a render — wire `useRefSignalRender` (or the unwrap form) explicitly.
 
@@ -56,7 +57,7 @@ Importing the broadcast or persist subpath is what activates the corresponding s
 
 ## Styles to avoid
 
-- **Don't call `.update()` / `.reset()` / `.notify()` on a `ReadonlySignal`** (e.g. a memo result). The type system rejects it; the operation fights the abstraction.
+- **Don't try to mutate a `ReadonlyRefSignal`** (e.g. a memo result) — `.update()` / `.reset()` / `.notify()` / `.notifyUpdate()` are hidden and `.current` / `.lastUpdated` are `readonly`. The type system rejects all of these; even if you cast around it, the next dep fire overwrites the change.
 - **Don't put `useGetXQuery()` inside the Provider body.** Use the sibling-leaf pattern.
 - **Don't subscribe with bare `signal.subscribe(fn)` inside a component.** Use `useRefSignalEffect` (cleanup is automatic) or `watch(signal, fn)` (returns a cleanup function for non-React code).
-- **Don't widen the type from `ReadonlySignal` back to `RefSignal` to mutate a memo result.** That mutation is overwritten on the next dep change.
+- **Don't cast a `ReadonlyRefSignal` back to `RefSignal` to bypass the readonly view.** That mutation is overwritten on the next dep change. If you need a writable signal, the right shape is a `useRefSignal` paired with the derivation done inline — not a memo result laundered into mutability.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 Mutable signal-like refs for React — update values without re-rendering, subscribe to changes, and opt into re-renders exactly where you need them.
 
+> **[Live demo →](https://stackblitz.com/edit/vitejs-vite-jurlgxkf?file=index.html)** — drag the nodes; sixty FPS, zero React re-renders.
+
 ## Why
 
 Imagine a canvas with a hundred draggable nodes, each connected by curves. The user drags one node — its position changes sixty times a second. Every curve attached to it must follow. The other ninety-nine nodes should be completely unaffected.
@@ -109,7 +111,7 @@ The full `docs/` folder is bundled with the npm package — installed at `node_m
 | `useRefSignal` vs `createRefSignal` | Inside a component vs anywhere else — both produce the same signal |
 | `useRefSignalEffect` vs `useRefSignalRender` | Imperative side effects vs triggering React re-renders |
 | `notify()` vs `notifyUpdate()` | Fire subscribers without or with bumping `lastUpdated` |
-| `createComputedSignal` / `useRefSignalMemo` | Derived signals — recompute whenever deps change; module-scope or component-scoped |
+| `createComputedRefSignal` / `useRefSignalMemo` | Derived signals — recompute whenever deps change; module-scope or component-scoped |
 | `watch(signal, listener, options?)` | Subscribe outside React and get a cleanup function back — mirrors `useEffect` return pattern; accepts the same `filter` and timing options as the hooks |
 | `EffectOptions` | Gate and rate-limit re-renders and effects via `filter`, `throttle`, `debounce`, `maxWait`, or `rAF` |
 | `createRefSignalStore` / `useRefSignalStore` | Provider-free global store — create at module scope, use in any component with `renderOn` opt-in |

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,8 +5,7 @@
 ---
 
 - [`RefSignal<T>`](#refsignalt)
-- [`ReadonlySignal<T>`](#readonlysignalt)
-- [`ComputedSignal<T>`](#computedsignalt)
+- [`ReadonlyRefSignal<T>`](#readonlyrefsignalt)
 - [`createRefSignal<T>(initialValue, options?)`](#createrefsignalt-initialvalue-options)
 - [`SignalOptions<T>` / `Interceptor<T>` / `CANCEL`](#signaloptionst--interceptort--cancel)
 - [`useRefSignal<T>(initialValue, options?)`](#userefsignalt-initialvalue-options)
@@ -19,7 +18,7 @@
 - [`SignalStoreOptions<TStore>`](#signalstoreoptionststore)
 - [`useRefSignalMemo<T>(factory, deps, options?)`](#userefsignalmemot-factory-deps-options)
 - [`useRefSignalFollow<T>(getter, deps, options?)`](#userefsignalfollowt-getter-deps-options)
-- [`createComputedSignal<T>(compute, deps)`](#createcomputedsignalt-compute-deps)
+- [`createComputedRefSignal<T>(compute, deps)`](#createcomputedrefsignalt-compute-deps)
 - [`watch<T>(signal, listener, options?)`](#watcht-signal-listener-options)
 - [`watchSignals(deps, onFire, options?)`](#watchsignalsdeps-onfire-options)
 - [`WatchHandle`](#watchhandle)
@@ -53,28 +52,26 @@ The core interface implemented by all signal objects.
 
 ---
 
-### `ReadonlySignal<T>`
+### `ReadonlyRefSignal<T>`
 
-Read-only view of a signal — `RefSignal<T>` minus the write-side APIs (`.update()`, `.reset()`, `.notify()`, `.notifyUpdate()`). Returned by [`useRefSignalMemo`](#userefsignalmemot-factory-deps-options) and [`useRefSignalFollow`](#userefsignalfollowt-getter-deps-options) where React owns the lifetime, so no `.dispose()` is exposed.
+Read-only view of a signal — `RefSignal<T>` minus the write-side APIs (`.update()`, `.reset()`, `.notify()`, `.notifyUpdate()`), with `.current` and `.lastUpdated` marked `readonly` so direct mutation (`signal.current = x`) is a compile-time error. Returned by [`useRefSignalMemo`](#userefsignalmemot-factory-deps-options) and [`useRefSignalFollow`](#userefsignalfollowt-getter-deps-options) where React owns the lifetime, so no `.dispose()` is exposed.
 
-`.notify()` and `.notifyUpdate()` are excluded because they are escape hatches for direct `.current` mutation — irrelevant when the value is derived.
+`.notify()` and `.notifyUpdate()` are excluded because they are escape hatches for the direct-`.current`-mutation pattern on a writable signal — irrelevant when the value is derived.
 
-`ReadonlySignal<T>` is the supertype of both `RefSignal<T>` and [`ComputedSignal<T>`](#computedsignalt). Use it as a parameter type whenever you only need to read or subscribe — your function will accept all three forms.
+`ReadonlyRefSignal<T>` is the supertype of `RefSignal<T>` and the return shape of [`createComputedRefSignal`](#createcomputedrefsignalt-compute-deps). Use it as a parameter type whenever you only need to read or subscribe — your function will accept all forms.
 
 ```ts
-function logChanges<T>(signal: ReadonlySignal<T>) {
+function logChanges<T>(signal: ReadonlyRefSignal<T>) {
   return signal.subscribe((v) => console.log(v));
 }
-logChanges(myRefSignal);      // ✓
+logChanges(myRefSignal);       // ✓
 logChanges(myMemoSignal);      // ✓ (from useRefSignalMemo)
-logChanges(myComputedSignal);  // ✓ (from createComputedSignal)
+logChanges(myComputedSignal);  // ✓ (from createComputedRefSignal)
 ```
 
----
+> **Ownership and `dispose`** — if a signal value carries `.dispose()` in its type (created via [`createRefSignal`](#createrefsignalt-initialvalue-options) or [`createComputedRefSignal`](#createcomputedrefsignalt-compute-deps)), you own its lifetime. `ReadonlyRefSignal<T>` itself does not include `.dispose()` — that only appears at creator return sites, so consumer functions taking a `ReadonlyRefSignal` can't accidentally tear down a signal they don't own.
 
-### `ComputedSignal<T>`
-
-`ReadonlySignal<T>` plus `.dispose()` — used at module scope where the lifetime is not React-managed. Returned by [`createComputedSignal`](#createcomputedsignalt-compute-deps). Calling `.dispose()` unsubscribes from dep signals and stops recomputation.
+> **Deprecated aliases** — `ReadonlySignal<T>` is kept as a deprecated alias for `ReadonlyRefSignal<T>`. `ComputedSignal<T>` is kept as a deprecated alias for `ReadonlyRefSignal<T> & { dispose: () => void }`. Both will be removed in a future major release.
 
 ---
 
@@ -112,6 +109,8 @@ const position = createRefSignal(0, {
 `lastUpdated` starts at `0` and is only incremented by `update()` or `notifyUpdate()`.
 
 > **Note:** `interceptor` runs inside `.update()` only. Direct mutation of `.current` bypasses it.
+
+The returned signal also carries `.dispose()`. Call it to tear down `broadcast` / `persist` adapter cleanups and proactively clear all subscribers from the WeakMap. Idempotent. Cleanup closures returned by prior `watch()` / `subscribe()` calls become safe no-ops afterwards. Re-subscribing after dispose works normally — the signal isn't permanently dead, just released. Inside React, prefer [`useRefSignal`](#userefsignalt-initialvalue-options) which manages this lifecycle for you (its return type intentionally omits `.dispose()`).
 
 ---
 
@@ -358,7 +357,7 @@ const result = useRefSignalMemo(
 - The returned signal can be subscribed to like any other signal.
 - `options` is a [`WatchOptions`](#watchoptions) — timing, filter, and `trackSignals` for dynamic-signal traversal.
 
-Returns a [`ReadonlySignal<T>`](#readonlysignalt) — read-side APIs (`.current`, `.lastUpdated`, `.subscribe`/`.unsubscribe`, `.getDebugName`) only; the write-side APIs (`.update`, `.reset`, `.notify`, `.notifyUpdate`) are hidden. The lifetime is tied to the component, so no `.dispose()` either. Pass it as a dep wherever a `ReadonlySignal` is accepted: `useRefSignalRender`, `useRefSignalEffect`, `useRefSignalMemo`, `useRefSignalFollow`, `createComputedSignal`, `watch`, `watchSignals`, and `WatchOptions.trackSignals`.
+Returns a [`ReadonlyRefSignal<T>`](#readonlyrefsignalt) — read-side APIs (`.current`, `.lastUpdated`, `.subscribe`/`.unsubscribe`, `.getDebugName`) only; the write-side APIs (`.update`, `.reset`, `.notify`, `.notifyUpdate`) are hidden. The lifetime is tied to the component, so no `.dispose()` either. Pass it as a dep wherever a `ReadonlyRefSignal` is accepted: `useRefSignalRender`, `useRefSignalEffect`, `useRefSignalMemo`, `useRefSignalFollow`, `createComputedRefSignal`, `watch`, `watchSignals`, and `WatchOptions.trackSignals`.
 
 ---
 
@@ -372,7 +371,7 @@ const node = useRefSignalFollow(
   () => nodes.current.get(focusedId),
   [nodes, focusedId],
 );
-// node: ReadonlySignal<NodeData | undefined>
+// node: ReadonlyRefSignal<NodeData | undefined>
 ```
 
 Shorthand for a [`useRefSignalMemo`](#userefsignalmemot-factory-deps-options) that reads `getter()?.current` while auto-tracking `getter()` as a dynamic signal. Use it whenever you would otherwise write a memo + matching `trackSignals` pair by hand.
@@ -382,18 +381,18 @@ Shorthand for a [`useRefSignalMemo`](#userefsignalmemot-factory-deps-options) th
 
 ---
 
-### `createComputedSignal<T>(compute, deps)`
+### `createComputedRefSignal<T>(compute, deps)`
 
 Creates a derived signal whose value is recomputed whenever any dep signal updates. The returned signal is read-only — `.update()` and `.reset()` are not exposed.
 
-Use this at module scope or in context factories. Inside a component, prefer [`useRefSignalMemo`](#userefsignalmemot-factory-deps), which ties the signal's lifetime to the component and handles non-signal deps via React's dependency array.
+Use this at module scope or in context factories. Inside a component, prefer [`useRefSignalMemo`](#userefsignalmemot-factory-deps-options), which ties the signal's lifetime to the component and handles non-signal deps via React's dependency array.
 
 ```ts
-import { createRefSignal, createComputedSignal } from 'react-refsignal';
+import { createRefSignal, createComputedRefSignal } from 'react-refsignal';
 
 const price = createRefSignal(10);
 const qty   = createRefSignal(3);
-const total = createComputedSignal(() => price.current * qty.current, [price, qty]);
+const total = createComputedRefSignal(() => price.current * qty.current, [price, qty]);
 
 total.current; // 30
 total.subscribe((v) => console.log('total:', v));
@@ -401,15 +400,17 @@ total.subscribe((v) => console.log('total:', v));
 price.update(20); // total → 60, subscriber called
 ```
 
-The computation stays live as long as at least one dep signal is alive (the computed signal holds subscriptions to each dep). Call `.dispose()` to unsubscribe and stop tracking:
+The computation stays live as long as at least one dep signal is alive (the computed signal holds subscriptions to each dep). Call `.dispose()` to unsubscribe from deps, stop recomputing, and proactively release the computed's own subscribers from the WeakMap:
 
 ```ts
-const total = createComputedSignal(() => price.current * qty.current, [price, qty]);
+const total = createComputedRefSignal(() => price.current * qty.current, [price, qty]);
 
-// Later — detach from deps, stop recomputing
+// Later — detach from deps, stop recomputing, release subscribers
 total.dispose();
 price.update(99); // total.current remains at the last computed value
 ```
+
+> **Deprecated alias** — `createComputedSignal` is kept as a deprecated alias and will be removed in a future major release. Migrate to `createComputedRefSignal` for brand consistency with the rest of the API.
 
 ---
 

--- a/docs/decision-tree.md
+++ b/docs/decision-tree.md
@@ -127,8 +127,8 @@ flowchart TD
 flowchart TD
     Q1{"Where do you need the derived value?"}
 
-    Q1 -->|Inside a React component| A["useRefSignalMemo(factory, deps, options?)\nTied to component lifetime\nDeps can mix signals and non-signals (props, state)\nReturns ReadonlySignal — no .dispose() (React owns cleanup)"]
-    Q1 -->|"Outside React — module scope, context factory"| B["createComputedSignal(compute, deps)\nDeps accept RefSignal / ReadonlySignal / ComputedSignal\nReturns ComputedSignal (= ReadonlySignal + .dispose())"]
+    Q1 -->|Inside a React component| A["useRefSignalMemo(factory, deps, options?)\nTied to component lifetime\nDeps can mix signals and non-signals (props, state)\nReturns ReadonlyRefSignal — no .dispose() (React owns cleanup)"]
+    Q1 -->|"Outside React — module scope, context factory"| B["createComputedRefSignal(compute, deps)\nDeps accept RefSignal / ReadonlyRefSignal\nReturns ReadonlyRefSignal + .dispose() — you own cleanup"]
 
     A --> Q3{"Need to rate-limit, filter, or follow dynamic signals?"}
     Q3 -->|Rate-limit the recompute| E["Add throttle / debounce / rAF — see Section 4"]
@@ -137,7 +137,7 @@ flowchart TD
     Q3 -->|No| H[Done]
 
     B --> Q2{"Created dynamically and discarded later?"}
-    Q2 -->|Yes| C["Call .dispose() to unsubscribe from deps and allow GC"]
+    Q2 -->|Yes| C["Call .dispose() to unsubscribe from deps, release subscribers, allow GC"]
     Q2 -->|"No — app lifetime"| D[No cleanup needed]
 ```
 
@@ -163,7 +163,7 @@ flowchart TD
     Q1 -->|"No — resolved through another signal's current value"| Q2
 
     Q2{"What shape do you need?"}
-    Q2 -->|"A stable signal I can pass downstream as a normal dep"| B["useRefSignalFollow(() => getter(), deps)\n→ ReadonlySignal<T | undefined>\nShorthand for the single-signal case"]
+    Q2 -->|"A stable signal I can pass downstream as a normal dep"| B["useRefSignalFollow(() => getter(), deps)\n→ ReadonlyRefSignal<T | undefined>\nShorthand for the single-signal case"]
     Q2 -->|"React to N dynamic signals in one effect or render"| C["options.trackSignals: () => signals[]\non useRefSignalEffect / useRefSignalMemo / useRefSignalRender\n(outside React: watchSignals with the same option)"]
 
     B & C --> D["Diff-subscribed on every static-dep fire.\nRef-equal + content-equal shortcuts skip the diff when the returned array is stable."]

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -531,7 +531,7 @@ import {
   useRefSignalRender,
   createRefSignalContextHook,
   type RefSignal,
-  type ReadonlySignal,
+  type ReadonlyRefSignal,
 } from 'react-refsignal';
 import { useBroadcast } from 'react-refsignal/broadcast';
 import { usePersist } from 'react-refsignal/persist';
@@ -540,7 +540,7 @@ import { useGetMessagesQuery } from './api';
 
 type MessagesStore = {
   messages: RefSignal<MessagesData | undefined>;
-  unreadCount: ReadonlySignal<number>;
+  unreadCount: ReadonlyRefSignal<number>;
 };
 
 const [MessagesContext, useMessagesContext] =

--- a/src/hooks/useRefSignalFollow.ts
+++ b/src/hooks/useRefSignalFollow.ts
@@ -1,5 +1,5 @@
 import { DependencyList } from 'react';
-import { ReadonlySignal } from '../refsignal';
+import { ReadonlyRefSignal } from '../refsignal';
 import { useRefSignalMemo } from './useRefSignalMemo';
 import type { WatchOptions } from '../timing';
 
@@ -53,10 +53,10 @@ export type FollowOptions = Omit<WatchOptions, 'trackSignals'>;
  * );
  */
 export function useRefSignalFollow<T>(
-  getter: () => ReadonlySignal<T> | null | undefined,
+  getter: () => ReadonlyRefSignal<T> | null | undefined,
   deps: DependencyList,
   options?: FollowOptions,
-): ReadonlySignal<T | undefined> {
+): ReadonlyRefSignal<T | undefined> {
   return useRefSignalMemo(() => getter()?.current, deps, {
     ...options,
     trackSignals: () => {

--- a/src/hooks/useRefSignalMemo.test.ts
+++ b/src/hooks/useRefSignalMemo.test.ts
@@ -21,23 +21,28 @@ describe('useRefSignalMemo', () => {
     expect(result.current.current).toBe(2);
   });
 
-  // Type-level: the returned ReadonlySignal hides every write-flavored API,
+  // Type-level: the returned ReadonlyRefSignal hides every write-flavored API,
   // including the `notify`/`notifyUpdate` escape hatches that only make sense
-  // when the caller mutated `.current` directly. This test compiling is the
-  // assertion.
-  it('returns a ReadonlySignal that hides write-side APIs (compile-time check)', () => {
+  // when the caller mutated `.current` directly. `.current` and `.lastUpdated`
+  // are also readonly — direct mutation is the same shape of misuse as `.update()`.
+  // This test compiling is the assertion.
+  it('returns a ReadonlyRefSignal that hides write-side APIs (compile-time check)', () => {
     const { result } = renderHook(() => {
       const signal = useRefSignal(1);
       const memo = useRefSignalMemo(() => signal.current * 2, [signal]);
 
-      // @ts-expect-error — `update` is not exposed on ReadonlySignal
+      // @ts-expect-error — `update` is not exposed on ReadonlyRefSignal
       void memo.update;
-      // @ts-expect-error — `reset` is not exposed on ReadonlySignal
+      // @ts-expect-error — `reset` is not exposed on ReadonlyRefSignal
       void memo.reset;
-      // @ts-expect-error — `notify` is not exposed on ReadonlySignal
+      // @ts-expect-error — `notify` is not exposed on ReadonlyRefSignal
       void memo.notify;
-      // @ts-expect-error — `notifyUpdate` is not exposed on ReadonlySignal
+      // @ts-expect-error — `notifyUpdate` is not exposed on ReadonlyRefSignal
       void memo.notifyUpdate;
+      // @ts-expect-error — `.current` is readonly on ReadonlyRefSignal
+      memo.current = 99;
+      // @ts-expect-error — `.lastUpdated` is readonly on ReadonlyRefSignal
+      memo.lastUpdated = 0;
 
       return memo;
     });

--- a/src/hooks/useRefSignalMemo.ts
+++ b/src/hooks/useRefSignalMemo.ts
@@ -1,5 +1,5 @@
 import { DependencyList, useEffect, useMemo, useRef } from 'react';
-import { ReadonlySignal } from '../refsignal';
+import { ReadonlyRefSignal } from '../refsignal';
 import { useRefSignal } from './useRefSignal';
 import { watchSignals } from '../watchSignals';
 import { useWatchArgs } from './useWatchArgs';
@@ -47,22 +47,22 @@ export function useRefSignalMemo<T>(
   factory: () => T,
   deps: DependencyList,
   options?: WatchOptions,
-): ReadonlySignal<T>;
+): ReadonlyRefSignal<T>;
 export function useRefSignalMemo<T>(
   factory: () => T | null,
   deps: DependencyList,
   options?: WatchOptions,
-): ReadonlySignal<T | null>;
+): ReadonlyRefSignal<T | null>;
 export function useRefSignalMemo<T>(
   factory: () => T | undefined,
   deps: DependencyList,
   options?: WatchOptions,
-): ReadonlySignal<T | undefined>;
+): ReadonlyRefSignal<T | undefined>;
 export function useRefSignalMemo<T>(
   factory: () => T | null | undefined,
   deps: DependencyList,
   options?: WatchOptions,
-): ReadonlySignal<T | null | undefined> {
+): ReadonlyRefSignal<T | null | undefined> {
   // Handles non-signal deps: React re-renders when state/props in deps change,
   // useMemo recomputes, and we sync the signal below — no extra factory() call needed.
   const memo = useMemo(factory, deps); // eslint-disable-line react-hooks/exhaustive-deps -- deps forwarded from caller

--- a/src/hooks/useRefSignalRender.ts
+++ b/src/hooks/useRefSignalRender.ts
@@ -1,5 +1,5 @@
 import { useCallback, useReducer, useRef, useSyncExternalStore } from 'react';
-import { ReadonlySignal } from '../refsignal';
+import { ReadonlyRefSignal } from '../refsignal';
 import { watchSignals, WatchHandle } from '../watchSignals';
 import { useWatchArgs } from './useWatchArgs';
 import type { WatchOptions } from '../timing';
@@ -51,7 +51,7 @@ import type { WatchOptions } from '../timing';
  */
 export function useRefSignalRender(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  deps: ReadonlySignal<any>[],
+  deps: ReadonlyRefSignal<any>[],
   callbackOrOptions?: (() => boolean) | WatchOptions,
 ): () => void {
   const [, forceUpdate] = useReducer((x: number) => x + 1, 0);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,21 +6,32 @@ export * from './hooks/useRefSignalFollow';
 export type {
   Listener,
   RefSignal,
-  ReadonlySignal,
-  ComputedSignal,
+  ReadonlyRefSignal,
   SignalOptions,
   Interceptor,
   DevToolsAdapter,
   SignalBroadcastInput,
   SignalPersistInput,
 } from './refsignal';
+// Deprecated type aliases re-exported for backward compatibility.
+export type {
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  ReadonlySignal,
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  ComputedSignal,
+} from './refsignal';
 export {
   batch,
   createRefSignal,
   isRefSignal,
   CANCEL,
-  createComputedSignal,
+  createComputedRefSignal,
   watch,
+} from './refsignal';
+// Deprecated factory re-exported for backward compatibility.
+export {
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  createComputedSignal,
 } from './refsignal';
 export {
   createRefSignalContext,

--- a/src/refsignal.test.ts
+++ b/src/refsignal.test.ts
@@ -5,6 +5,7 @@ import {
   CANCEL,
   createComputedSignal,
   watch,
+  listenersMap,
 } from './refsignal';
 import { setupRafMock } from './test-utils/raf';
 
@@ -219,6 +220,108 @@ describe('createRefSignal', () => {
       signal.update(99);
       signal.reset();
       expect(signal.current).toBe(0);
+    });
+  });
+
+  describe('dispose', () => {
+    it('clears subscribers — listener no longer fires after dispose', () => {
+      const signal = createRefSignal(0);
+      const listener = jest.fn();
+      signal.subscribe(listener);
+      signal.dispose();
+      signal.update(1);
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('allows re-subscribing after dispose', () => {
+      const signal = createRefSignal(0);
+      signal.dispose();
+      const listener = jest.fn();
+      signal.subscribe(listener);
+      signal.update(1);
+      expect(listener).toHaveBeenCalledWith(1);
+    });
+
+    it('runs broadcast adapter cleanup on dispose', async () => {
+      await jest.isolateModulesAsync(async () => {
+        const { setSignalBroadcastAdapter, createRefSignal: create } =
+          await import('./refsignal');
+        const cleanup = jest.fn();
+        setSignalBroadcastAdapter({ attach: () => cleanup });
+        const signal = create(0, { broadcast: 'channel' });
+        signal.dispose();
+        expect(cleanup).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('runs persist adapter cleanup on dispose', async () => {
+      await jest.isolateModulesAsync(async () => {
+        const { setSignalPersistAdapter, createRefSignal: create } =
+          await import('./refsignal');
+        const cleanup = jest.fn();
+        setSignalPersistAdapter({ attach: () => cleanup });
+        const signal = create(0, { persist: 'my-key' });
+        signal.dispose();
+        expect(cleanup).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('is idempotent — second dispose does not re-run cleanups', async () => {
+      await jest.isolateModulesAsync(async () => {
+        const { setSignalBroadcastAdapter, createRefSignal: create } =
+          await import('./refsignal');
+        const cleanup = jest.fn();
+        setSignalBroadcastAdapter({ attach: () => cleanup });
+        const signal = create(0, { broadcast: 'channel' });
+        signal.dispose();
+        signal.dispose();
+        expect(cleanup).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('supports re-attaching listeners and adapters after dispose', async () => {
+      await jest.isolateModulesAsync(async () => {
+        const {
+          setSignalBroadcastAdapter,
+          setSignalPersistAdapter,
+          attachSignalBroadcast,
+          attachSignalPersist,
+          createRefSignal: create,
+        } = await import('./refsignal');
+
+        const broadcastCleanup = jest.fn();
+        const persistCleanup = jest.fn();
+        setSignalBroadcastAdapter({ attach: () => broadcastCleanup });
+        setSignalPersistAdapter({ attach: () => persistCleanup });
+
+        const signal = create(0, { broadcast: 'channel', persist: 'key' });
+        const original = jest.fn();
+        signal.subscribe(original);
+
+        signal.dispose();
+        expect(broadcastCleanup).toHaveBeenCalledTimes(1);
+        expect(persistCleanup).toHaveBeenCalledTimes(1);
+
+        // Re-attach: signal isn't permanently dead, just released.
+        const replacement = jest.fn();
+        signal.subscribe(replacement);
+        const reBroadcastCleanup = attachSignalBroadcast(signal, 'channel');
+        const rePersistCleanup = attachSignalPersist(signal, 'key');
+
+        signal.update(42);
+        expect(original).not.toHaveBeenCalled();
+        expect(replacement).toHaveBeenCalledWith(42);
+
+        // Cleanups returned from the re-attach are independent of the signal —
+        // calling them tears down only that re-attached binding, listeners stay.
+        reBroadcastCleanup?.();
+        rePersistCleanup?.();
+        expect(broadcastCleanup).toHaveBeenCalledTimes(2);
+        expect(persistCleanup).toHaveBeenCalledTimes(2);
+
+        signal.update(99);
+        expect(replacement).toHaveBeenCalledWith(99);
+      });
     });
   });
 });
@@ -457,6 +560,17 @@ describe('createComputedSignal', () => {
     doubled.dispose();
     source.update(10);
     expect(listener).toHaveBeenCalledWith(10); // other subscribers unaffected
+  });
+
+  it('dispose clears subscribers on the computed signal itself', () => {
+    const source = createRefSignal(1);
+    const doubled = createComputedSignal(() => source.current * 2, [source]);
+    const listener = jest.fn();
+    doubled.subscribe(listener);
+    doubled.dispose();
+    // Even if something forced a value through (e.g. another computed sharing state),
+    // prior subscribers must not fire. The contract is "after dispose, subscribers are released."
+    expect(listenersMap.has(doubled)).toBe(false);
   });
 });
 

--- a/src/refsignal.test.ts
+++ b/src/refsignal.test.ts
@@ -3,7 +3,7 @@ import {
   isRefSignal,
   batch,
   CANCEL,
-  createComputedSignal,
+  createComputedRefSignal,
   watch,
   listenersMap,
 } from './refsignal';
@@ -507,27 +507,33 @@ describe('batch', () => {
   });
 });
 
-// ─── createComputedSignal ─────────────────────────────────────────────────────
+// ─── createComputedRefSignal ─────────────────────────────────────────────────────
 
-describe('createComputedSignal', () => {
+describe('createComputedRefSignal', () => {
   it('initialises with the computed value', () => {
     const a = createRefSignal(2);
     const b = createRefSignal(3);
-    const product = createComputedSignal(() => a.current * b.current, [a, b]);
+    const product = createComputedRefSignal(
+      () => a.current * b.current,
+      [a, b],
+    );
     expect(product.current).toBe(6);
   });
 
   it('recomputes when a dep updates', () => {
     const a = createRefSignal(2);
     const b = createRefSignal(3);
-    const product = createComputedSignal(() => a.current * b.current, [a, b]);
+    const product = createComputedRefSignal(
+      () => a.current * b.current,
+      [a, b],
+    );
     a.update(5);
     expect(product.current).toBe(15);
   });
 
   it('notifies subscribers on recompute', () => {
     const source = createRefSignal(1);
-    const doubled = createComputedSignal(() => source.current * 2, [source]);
+    const doubled = createComputedRefSignal(() => source.current * 2, [source]);
     const listener = jest.fn();
     doubled.subscribe(listener);
     source.update(4);
@@ -537,7 +543,7 @@ describe('createComputedSignal', () => {
   it('does not recompute when value is unchanged', () => {
     const source = createRefSignal(0);
     const compute = jest.fn(() => Math.abs(source.current));
-    const abs = createComputedSignal(compute, [source]);
+    const abs = createComputedRefSignal(compute, [source]);
     compute.mockClear();
     source.update(0); // same value — update() is a no-op on source
     expect(compute).not.toHaveBeenCalled();
@@ -546,7 +552,7 @@ describe('createComputedSignal', () => {
 
   it('stops recomputing after dispose', () => {
     const source = createRefSignal(1);
-    const doubled = createComputedSignal(() => source.current * 2, [source]);
+    const doubled = createComputedRefSignal(() => source.current * 2, [source]);
     doubled.dispose();
     source.update(5);
     expect(doubled.current).toBe(2); // frozen at initial value
@@ -554,7 +560,7 @@ describe('createComputedSignal', () => {
 
   it('dispose does not affect other subscribers', () => {
     const source = createRefSignal(1);
-    const doubled = createComputedSignal(() => source.current * 2, [source]);
+    const doubled = createComputedRefSignal(() => source.current * 2, [source]);
     const listener = jest.fn();
     source.subscribe(listener);
     doubled.dispose();
@@ -564,7 +570,7 @@ describe('createComputedSignal', () => {
 
   it('dispose clears subscribers on the computed signal itself', () => {
     const source = createRefSignal(1);
-    const doubled = createComputedSignal(() => source.current * 2, [source]);
+    const doubled = createComputedRefSignal(() => source.current * 2, [source]);
     const listener = jest.fn();
     doubled.subscribe(listener);
     doubled.dispose();

--- a/src/refsignal.ts
+++ b/src/refsignal.ts
@@ -291,21 +291,25 @@ export function createRefSignal<T = unknown>(
 }
 
 /**
- * A read-only signal. Exposes subscription and current value but not
- * `.update()`, `.reset()`, `.notify()`, or `.notifyUpdate()`. Returned by
- * {@link useRefSignalMemo} (where React owns the lifetime — no `dispose`
- * is exposed).
+ * A read-only signal. Exposes subscription and current value but not the
+ * write-side APIs — `.update()`, `.reset()`, `.notify()`, `.notifyUpdate()`
+ * are hidden, and `.current` / `.lastUpdated` are readonly so direct mutation
+ * is rejected at compile time. Returned by {@link useRefSignalMemo} (where
+ * React owns the lifetime — no `dispose` is exposed).
  *
- * Both `notify` and `notifyUpdate` are escape hatches for direct `.current`
- * mutation, which doesn't apply when the value is derived. Supertype of
- * `RefSignal` and the return shape of {@link createComputedRefSignal}:
+ * `notify` / `notifyUpdate` are escape hatches for the direct-`.current`-mutation
+ * pattern on a writable signal — neither applies when the value is derived.
+ * Supertype of `RefSignal` and the return shape of {@link createComputedRefSignal}:
  * anything that accepts `ReadonlyRefSignal<T>` accepts the read-write or
  * computed forms too.
  */
 export type ReadonlyRefSignal<T> = Omit<
   RefSignal<T>,
-  'update' | 'reset' | 'notify' | 'notifyUpdate'
->;
+  'update' | 'reset' | 'notify' | 'notifyUpdate' | 'current' | 'lastUpdated'
+> & {
+  readonly current: T;
+  readonly lastUpdated: number;
+};
 
 /** @deprecated Renamed to {@link ReadonlyRefSignal}. */
 export type ReadonlySignal<T> = ReadonlyRefSignal<T>;

--- a/src/refsignal.ts
+++ b/src/refsignal.ts
@@ -142,7 +142,7 @@ export function isRefSignal<T = unknown>(obj: unknown): obj is RefSignal<T> {
 }
 
 export function subscribe<T>(
-  signal: ReadonlySignal<T>,
+  signal: ReadonlyRefSignal<T>,
   listener: Listener<T>,
 ): void {
   if (!listenersMap.has(signal)) {
@@ -158,7 +158,7 @@ export function subscribe<T>(
  * dispose.
  */
 export function unsubscribe<T>(
-  signal: ReadonlySignal<T>,
+  signal: ReadonlyRefSignal<T>,
   listener: Listener<T>,
 ): void {
   const listeners = listenersMap.get(signal);
@@ -298,20 +298,20 @@ export function createRefSignal<T = unknown>(
  *
  * Both `notify` and `notifyUpdate` are escape hatches for direct `.current`
  * mutation, which doesn't apply when the value is derived. Supertype of
- * both {@link RefSignal} and {@link ComputedSignal}: anything that accepts
- * `ReadonlySignal<T>` accepts the read-write or computed forms too.
+ * `RefSignal` and the return shape of {@link createComputedRefSignal}:
+ * anything that accepts `ReadonlyRefSignal<T>` accepts the read-write or
+ * computed forms too.
  */
-export type ReadonlySignal<T> = Omit<
+export type ReadonlyRefSignal<T> = Omit<
   RefSignal<T>,
   'update' | 'reset' | 'notify' | 'notifyUpdate'
 >;
 
-/**
- * A read-only derived signal with a managed lifetime. Adds `.dispose()` to
- * {@link ReadonlySignal} so callers can stop tracking dep signals when the
- * computed value is no longer needed. Returned by {@link createComputedSignal}.
- */
-export type ComputedSignal<T> = ReadonlySignal<T> & {
+/** @deprecated Renamed to {@link ReadonlyRefSignal}. */
+export type ReadonlySignal<T> = ReadonlyRefSignal<T>;
+
+/** @deprecated Use the inline type `ReadonlyRefSignal<T> & { dispose: () => void }`, returned by {@link createComputedRefSignal}. */
+export type ComputedSignal<T> = ReadonlyRefSignal<T> & {
   readonly dispose: () => void;
 };
 
@@ -322,7 +322,8 @@ export type ComputedSignal<T> = ReadonlySignal<T> & {
  *
  *
  * The computed signal is read-only — calling `.update()` or `.reset()` is not exposed.
- * The computation stays live as long as any dep signal is alive.
+ * The returned signal exposes `.dispose()` — call it to stop watching dep signals
+ * and release subscribers on the computed itself.
  *
  * For React components, prefer {@link useRefSignalMemo} which ties the lifetime to the
  * component and handles non-signal deps (props, state) via React's dependency array.
@@ -330,15 +331,15 @@ export type ComputedSignal<T> = ReadonlySignal<T> & {
  * @example
  * const price = createRefSignal(10);
  * const qty   = createRefSignal(3);
- * const total = createComputedSignal(() => price.current * qty.current, [price, qty]);
+ * const total = createComputedRefSignal(() => price.current * qty.current, [price, qty]);
  * total.subscribe(v => console.log('total:', v)); // 30
  * price.update(20); // total → 60
  */
-export function createComputedSignal<T>(
+export function createComputedRefSignal<T>(
   compute: () => T,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  deps: ReadonlySignal<any>[],
-): ComputedSignal<T> {
+  deps: ReadonlyRefSignal<any>[],
+): ReadonlyRefSignal<T> & { readonly dispose: () => void } {
   const signal = createRefSignal(compute());
   const recompute = () => {
     signal.update(compute());
@@ -354,6 +355,9 @@ export function createComputedSignal<T>(
     },
   });
 }
+
+/** @deprecated Renamed to {@link createComputedRefSignal}. */
+export const createComputedSignal = createComputedRefSignal;
 
 /**
  * Subscribes a listener to a signal and returns a cleanup function.
@@ -382,7 +386,7 @@ export function createComputedSignal<T>(
  * const stop = watch(score, (v) => log(v), { filter: () => score.current > 0 });
  */
 export function watch<T>(
-  signal: ReadonlySignal<T>,
+  signal: ReadonlyRefSignal<T>,
   listener: Listener<T>,
   // `trackSignals` is excluded here — `watch()` is single-signal and cannot
   // express "fire my value-delivering listener when a different signal updates"

--- a/src/refsignal.ts
+++ b/src/refsignal.ts
@@ -151,6 +151,12 @@ export function subscribe<T>(
   listenersMap.get(signal)?.add(listener as Listener);
 }
 
+/**
+ * Removes a listener from a signal. Safe to call on a signal whose listener
+ * set has already been cleared (e.g. by `dispose()`) — this is what makes
+ * cleanup closures returned by `watch()`/`subscribe()` no-op safely after
+ * dispose.
+ */
 export function unsubscribe<T>(
   signal: ReadonlySignal<T>,
   listener: Listener<T>,
@@ -210,13 +216,19 @@ export function update<T>(signal: RefSignal<T>, value: T) {
  *
  * @see [Decision Tree §1 — Signal Creation](https://github.com/jav974/react-refsignal/blob/main/docs/decision-tree.md#1-signal-creation)
  *
- * Returns a {@link RefSignal} with `.current`, `.update()`, `.reset()`, `.subscribe()`, and notification methods.
- * Inside a React component, prefer {@link useRefSignal} so the signal's lifetime is tied to the component.
+ * Returns a {@link RefSignal} with `.current`, `.update()`, `.reset()`, `.subscribe()`, notification methods,
+ * and `.dispose()`. Inside a React component, prefer {@link useRefSignal} so the signal's lifetime
+ * is tied to the component (the hook's return type intentionally omits `.dispose()` — React owns
+ * cleanup there).
+ *
+ * **Dispose semantics:** calling `.dispose()` runs adapter cleanups (broadcast, persist) and clears
+ * all subscribers from the WeakMap. Idempotent. Cleanup closures returned by prior `watch()` /
+ * `subscribe()` calls become safe no-ops afterwards. Re-subscribing after dispose works normally.
  */
 export function createRefSignal<T = unknown>(
   initialValue: T,
   options?: string | SignalOptions<T>,
-): RefSignal<T> {
+): RefSignal<T> & { readonly dispose: () => void } {
   const resolved =
     typeof options === 'string' ? { debugName: options } : options;
   const { debugName, interceptor, equal } = resolved ?? {};
@@ -226,7 +238,9 @@ export function createRefSignal<T = unknown>(
     : initialValue;
   const safeInitial = intercepted === CANCEL ? initialValue : intercepted;
 
-  const signal: RefSignal<T> = {
+  const cleanups: Array<() => void> = [];
+
+  const signal: RefSignal<T> & { dispose: () => void } = {
     current: safeInitial,
     lastUpdated: 0,
     subscribe: (listener: Listener<T>) => {
@@ -251,16 +265,26 @@ export function createRefSignal<T = unknown>(
       signal.update(safeInitial);
     },
     getDebugName: () => devtoolsAdapter?.getSignalName(signal),
+    dispose: () => {
+      let fn = cleanups.pop();
+      while (fn) {
+        fn();
+        fn = cleanups.pop();
+      }
+      listenersMap.delete(signal);
+    },
   };
 
   devtoolsAdapter?.registerSignal(signal, debugName);
 
   if (resolved?.broadcast) {
-    attachSignalBroadcast(signal, resolved.broadcast);
+    const cleanup = attachSignalBroadcast(signal, resolved.broadcast);
+    if (cleanup) cleanups.push(cleanup);
   }
 
   if (resolved?.persist) {
-    attachSignalPersist(signal, resolved.persist);
+    const cleanup = attachSignalPersist(signal, resolved.persist);
+    if (cleanup) cleanups.push(cleanup);
   }
 
   return signal;
@@ -319,12 +343,14 @@ export function createComputedSignal<T>(
   const recompute = () => {
     signal.update(compute());
   };
-  const cleanups = deps.map((dep) => watch(dep, recompute));
+  const watchCleanups = deps.map((dep) => watch(dep, recompute));
+  const baseDispose = signal.dispose;
   return Object.assign(signal, {
     dispose: () => {
-      cleanups.forEach((stop) => {
+      watchCleanups.forEach((stop) => {
         stop();
       });
+      baseDispose();
     },
   });
 }

--- a/src/timing.ts
+++ b/src/timing.ts
@@ -5,7 +5,7 @@
  */
 
 // Type-only import — avoids a runtime circular dep with `refsignal.ts`.
-import type { ReadonlySignal } from './refsignal';
+import type { ReadonlyRefSignal } from './refsignal';
 
 /**
  * Discriminated union of mutually exclusive timing strategies.
@@ -52,8 +52,8 @@ export interface TimingWrapper {
  */
 export type WatchOptions = TimingOptions & {
   filter?: () => boolean;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches `createComputedSignal` / `batch` signal-array conventions
-  trackSignals?: () => ReadonlyArray<ReadonlySignal<any>>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches `createComputedRefSignal` / `batch` signal-array conventions
+  trackSignals?: () => ReadonlyArray<ReadonlyRefSignal<any>>;
 };
 
 /**

--- a/src/watchSignals.ts
+++ b/src/watchSignals.ts
@@ -13,7 +13,7 @@
  * See `WatchOptions` in `./timing` for option semantics.
  */
 
-import { isRefSignal, type ReadonlySignal } from './refsignal';
+import { isRefSignal, type ReadonlyRefSignal } from './refsignal';
 import {
   applyTimingOptions,
   type TimingOptions,
@@ -37,7 +37,7 @@ export interface WatchHandle {
    * static and dynamic deps.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  trackedSignals(): ReadonlySignal<any>[];
+  trackedSignals(): ReadonlyRefSignal<any>[];
 }
 
 /**
@@ -107,10 +107,10 @@ export function watchSignals(
   const filter = options?.filter;
 
   let reconcileNeeded = false;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches `createComputedSignal` / `batch` signal-array conventions
-  let tracked: Set<ReadonlySignal<any>> = new Set();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches `createComputedRefSignal` / `batch` signal-array conventions
+  let tracked: Set<ReadonlyRefSignal<any>> = new Set();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let lastTrackedResult: ReadonlyArray<ReadonlySignal<any>> | undefined;
+  let lastTrackedResult: ReadonlyArray<ReadonlyRefSignal<any>> | undefined;
   let disposed = false;
 
   const reconcile = () => {


### PR DESCRIPTION
## Summary

Type-system honesty pass on top of the existing API.

- **`dispose()` on signal returns.** `createRefSignal` now returns `RefSignal<T> & { readonly dispose: () => void }`; `createComputedRefSignal` returns the readonly equivalent. Calling `.dispose()` runs adapter cleanups (broadcast/persist), clears subscribers from the `WeakMap`, and is idempotent. Also fixes a latent leak: `createRefSignal` was previously dropping the cleanup functions returned by broadcast/persist adapters at module scope.
- **Brand-consistent renames.** `ReadonlySignal` → `ReadonlyRefSignal`, `createComputedSignal` → `createComputedRefSignal`. Old names kept as `@deprecated` aliases (re-exported from the index with scoped eslint-disable).
- **Ownership rule.** The shape `& { readonly dispose: () => void }` only appears at creator return sites — never on `RefSignal<T>` or `ReadonlyRefSignal<T>` themselves, never on hook returns. So consumer functions taking the universal contract types can't accidentally tear down a signal they don't own. "If you see `dispose`, you own it."
- **Readonly tightening.** `ReadonlyRefSignal.current` and `.lastUpdated` are now `readonly` so direct mutation of a memo result is rejected at compile time. `RefSignal.current` stays writable to support the `signal.current = x; signal.notify()` escape hatch.

## Commits

Each compiles + passes tests independently.

1. `feat: dispose() on signal returns; clear subscribers`
2. `refactor: rename to ReadonlyRefSignal and createComputedRefSignal`
3. `feat: readonly current and lastUpdated on ReadonlyRefSignal`
4. `docs: dispose, ownership rule, readonly tightening`

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npx jest` — 465/465 pass (7 new tests: 5 createRefSignal dispose, 1 computed subscriber-clear, 1 full re-attach roundtrip; existing memo compile-time test extended with two `@ts-expect-error` lines for `.current = x` / `.lastUpdated = x`)
- [ ] Spot-check downstream consumers (`react-refsignal-query`, `dataflow-ide`) — `dataflow-ide` already verified clean for the readonly tightening; `rsquery` not yet swept.