### PR TITLE
feat: pulse signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The canvas redraws at every frame via `useRefSignalEffect` — React's render cy
 - [API Reference](docs/api.md) — every hook and function with examples.
 - [Concepts](docs/concepts.md) — signals, notify vs notifyUpdate, effect vs render, signal lifetime.
 - [Imperative renderers](docs/imperative-renderers.md) — Canvas / Pixi / WebGL / audio driven by signals, bypassing React reconciliation.
+- [Pulse](docs/pulse.md) — self-firing signals (`createPulseRefSignal` / `usePulseRefSignal`): clocks, game loops, auth refresh, shared tick across components.
 - [Cross-tab Broadcast](docs/broadcast.md) — sync signals across tabs with `react-refsignal/broadcast`.
 - [Persist](docs/persist.md) — persist signals across page loads with `react-refsignal/persist`.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,11 +1,13 @@
 # API Reference
 
-← [Back to README](../README.md) · [Concepts](concepts.md) · [Patterns](patterns.md) · [Imperative renderers](imperative-renderers.md) · [Broadcast](broadcast.md) · [Persist](persist.md)
+← [Back to README](../README.md) · [Concepts](concepts.md) · [Patterns](patterns.md) · [Imperative renderers](imperative-renderers.md) · [Pulse](pulse.md) · [Broadcast](broadcast.md) · [Persist](persist.md)
 
 ---
 
 - [`RefSignal<T>`](#refsignalt)
 - [`ReadonlyRefSignal<T>`](#readonlyrefsignalt)
+- [`PulseRefSignal`](#pulserefsignal)
+- [`PulseRate`](#pulserate)
 - [`createRefSignal<T>(initialValue, options?)`](#createrefsignalt-initialvalue-options)
 - [`SignalOptions<T>` / `Interceptor<T>` / `CANCEL`](#signaloptionst--interceptort--cancel)
 - [`useRefSignal<T>(initialValue, options?)`](#userefsignalt-initialvalue-options)
@@ -18,7 +20,9 @@
 - [`SignalStoreOptions<TStore>`](#signalstoreoptionststore)
 - [`useRefSignalMemo<T>(factory, deps, options?)`](#userefsignalmemot-factory-deps-options)
 - [`useRefSignalFollow<T>(getter, deps, options?)`](#userefsignalfollowt-getter-deps-options)
+- [`usePulseRefSignal(rate)`](#usepulserefsignalrate)
 - [`createComputedRefSignal<T>(compute, deps)`](#createcomputedrefsignalt-compute-deps)
+- [`createPulseRefSignal(rate)`](#createpulserefsignalrate)
 - [`watch<T>(signal, listener, options?)`](#watcht-signal-listener-options)
 - [`watchSignals(deps, onFire, options?)`](#watchsignalsdeps-onfire-options)
 - [`WatchHandle`](#watchhandle)
@@ -72,6 +76,45 @@ logChanges(myComputedSignal);  // ✓ (from createComputedRefSignal)
 > **Ownership and `dispose`** — if a signal value carries `.dispose()` in its type (created via [`createRefSignal`](#createrefsignalt-initialvalue-options) or [`createComputedRefSignal`](#createcomputedrefsignalt-compute-deps)), you own its lifetime. `ReadonlyRefSignal<T>` itself does not include `.dispose()` — that only appears at creator return sites, so consumer functions taking a `ReadonlyRefSignal` can't accidentally tear down a signal they don't own.
 
 > **Deprecated aliases** — `ReadonlySignal<T>` is kept as a deprecated alias for `ReadonlyRefSignal<T>`. `ComputedSignal<T>` is kept as a deprecated alias for `ReadonlyRefSignal<T> & { dispose: () => void }`. Both will be removed in a future major release.
+
+---
+
+### `PulseRefSignal`
+
+A self-firing read-only signal whose `.current` advances to `performance.now()` on every tick. Returned by [`createPulseRefSignal`](#createpulserefsignalrate) and [`usePulseRefSignal`](#usepulserefsignalrate). Conceptually a clock primitive — see [Pulse](pulse.md) for the narrative and recipes.
+
+`PulseRefSignal` extends `ReadonlyRefSignal<number>` with three additional readonly fields. They are **tick-context metadata**, not parallel reactive channels — coherent with `.current` at the moment subscribers fire, like `event.timeStamp` inside a DOM event handler. You read them inside a tick callback; you don't `watch(loop.dt, …)`.
+
+| Member | Description |
+|---|---|
+| `current: number` | `performance.now()` at the most recent tick. Inherited from `ReadonlyRefSignal<number>`. Bumps `lastUpdated`, fires subscribers. |
+| `lastUpdated: number` | Inherited. Advances on every tick. |
+| `dt: number` | Milliseconds since the previous tick in the current session. Reset to `0` whenever the timer (re)starts. |
+| `tick: number` | Number of ticks fired in the current session. `0` before the first fire, increments by `1` each tick. Reset on (re)start. |
+| `elapsed: number` | Milliseconds since the first tick of the current session. `0` until the second tick. Reset on (re)start. |
+| `subscribe(listener)` / `unsubscribe(listener)` | Inherited. Subscribers drive the lazy lifecycle: timer starts on `0 → 1`, stops on `1 → 0`. |
+| `updatePulse(rate)` | Change the cadence of an already-created pulse signal. Validates the new rate, then if the timer is running, stops it and restarts at the new cadence with **continuity preserved** (`tick` and `elapsed` keep accumulating; only `lastTickTime` is reset so the next `dt` reflects the rate change). If no subscribers are attached, the new rate is just stored and applied on the next `0 → 1` start. Driver may switch (`'1000ms'` → `'60fps'` swaps `setInterval` for RAF). See [pulse.md — Reactive cadences](pulse.md#reactive-cadences-with-updatepulse). |
+| `getDebugName?()` | Inherited. |
+
+> **Why a number, not an object?** Most use cases (clocks, "X ago", token TTLs) want `.current` to be a primitive. The metadata-on-the-side shape pays the cost where it lands: game/sim code, where `loop.dt` is one identifier instead of a destructure. See [pulse.md — The shape of a pulse signal](pulse.md#the-shape-of-a-pulse-signal).
+
+---
+
+### `PulseRate`
+
+The cadence accepted by [`createPulseRefSignal`](#createpulserefsignalrate) and [`usePulseRefSignal`](#usepulserefsignalrate).
+
+```ts
+type PulseRate = number | `${number}ms` | `${number}fps`;
+```
+
+| Form | Driver | When to reach for it |
+|---|---|---|
+| `number` (e.g. `100`) | `setInterval` | Same as the `'Nms'` form — a bare number is implicitly milliseconds. |
+| `'Nms'` (e.g. `'250ms'`, `'16.67ms'`) | `setInterval` | Continues firing on hidden tabs (subject to browser background-tab throttling). Use for clocks, polling, heartbeats, token refresh. |
+| `'Nfps'` (e.g. `'60fps'`, `'30fps'`) | `requestAnimationFrame` | Frame-aligned, paused on hidden tabs, capped by display refresh rate. Use for game loops, animations. |
+
+Decimals are accepted in both string forms. A non-positive or non-finite rate throws at construction.
 
 ---
 
@@ -381,6 +424,34 @@ Shorthand for a [`useRefSignalMemo`](#userefsignalmemot-factory-deps-options) th
 
 ---
 
+### `usePulseRefSignal(rate)`
+
+Creates a [`PulseRefSignal`](#pulserefsignal) inside a React component — a self-firing read-only signal whose `.current` advances to `performance.now()` on every tick. The signal is stable for the component's lifetime and disposed on unmount; React owns the lifecycle, so `.dispose()` is not exposed.
+
+```tsx
+import { usePulseRefSignal, useRefSignalRender } from 'react-refsignal';
+
+function Clock() {
+  const now = usePulseRefSignal('1000ms');
+  useRefSignalRender([now]);
+  return <span>{new Date().toLocaleTimeString()}</span>;
+}
+
+function GameLoop() {
+  const loop = usePulseRefSignal('60fps');
+  useRefSignalEffect(() => {
+    advancePhysics(loop.dt);
+  }, [loop]);
+  return null;
+}
+```
+
+- `rate` is captured at mount time. Subsequent renders with a different `rate` keep the original cadence — mirrors the mount-time-options convention used by [`useRefSignal`](#userefsignalt-initialvalue-options).
+- The timer is **lazy**: it starts on the first subscriber and stops when subscribers drop to zero. Multiple consumers (e.g. several `useRefSignalRender` calls or a `useRefSignalEffect`) share one timer.
+- See [Pulse](pulse.md) for narrative, recipes (live timestamps, auth refresh, game loops, shared tick via provider), and what pulse can't compose with (`persist`, `broadcast`, both at signal- and store-level).
+
+---
+
 ### `createComputedRefSignal<T>(compute, deps)`
 
 Creates a derived signal whose value is recomputed whenever any dep signal updates. The returned signal is read-only — `.update()` and `.reset()` are not exposed.
@@ -411,6 +482,28 @@ price.update(99); // total.current remains at the last computed value
 ```
 
 > **Deprecated alias** — `createComputedSignal` is kept as a deprecated alias and will be removed in a future major release. Migrate to `createComputedRefSignal` for brand consistency with the rest of the API.
+
+---
+
+### `createPulseRefSignal(rate)`
+
+Creates a [`PulseRefSignal`](#pulserefsignal) outside React — at module scope, in context factories, or anywhere else. Returns the signal augmented with `.dispose()`.
+
+```ts
+import { createPulseRefSignal } from 'react-refsignal';
+
+const now      = createPulseRefSignal('1000ms');  // every second
+const loop     = createPulseRefSignal('60fps');   // frame-locked
+const everyHalf = createPulseRefSignal(500);      // bare number — same as '500ms'
+```
+
+- The timer is **lazy**: it starts on the `0 → 1` subscriber transition and stops on `1 → 0` and on `.dispose()`. A signal that is never subscribed to never installs a timer.
+- Each subscribe-cycle is a fresh session: `dt`, `tick`, and `elapsed` reset on (re)start, so a brief unsubscribe-then-resubscribe doesn't show up as a giant `dt` spike across the idle gap.
+- Driver: `'Nfps'` → `requestAnimationFrame` (frame-aligned, paused on hidden tabs); `number` / `'Nms'` → `setInterval` (continues firing on hidden tabs, subject to browser throttling).
+- **No `persist` / `broadcast` options.** They're absent intentionally — `performance.now()` is bound to the document's `performance.timeOrigin` and is meaningless to serialize or send across tabs. The same applies when a `PulseRefSignal` is placed inside a store wrapped by `persist()` or `broadcast()`: the type system doesn't catch this, but the runtime behavior is broken in the same ways. See [pulse.md — What pulse can't compose with](pulse.md#what-pulse-cant-compose-with).
+- SSR-safe: construction works in non-browser environments (so server output is stable), but no timer is installed when `typeof window === 'undefined'`. The timer starts naturally on the client after hydration.
+
+For full narrative, recipes, and the store-level composition trap, see [Pulse](pulse.md).
 
 ---
 

--- a/docs/broadcast.md
+++ b/docs/broadcast.md
@@ -1,6 +1,6 @@
 # Cross-tab Broadcast
 
-← [Back to README](../README.md) · [API Reference](api.md) · [Patterns](patterns.md)
+← [Back to README](../README.md) · [API Reference](api.md) · [Patterns](patterns.md) · [Pulse](pulse.md)
 
 ---
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,6 +1,6 @@
 # Concepts
 
-← [Back to README](../README.md) · [API Reference](api.md) · [Patterns](patterns.md) · [Imperative renderers](imperative-renderers.md) · [Broadcast](broadcast.md)
+← [Back to README](../README.md) · [API Reference](api.md) · [Patterns](patterns.md) · [Imperative renderers](imperative-renderers.md) · [Pulse](pulse.md) · [Broadcast](broadcast.md)
 
 ---
 
@@ -8,6 +8,7 @@
 - [`useRefSignal` vs `createRefSignal`](#userefsignal-vs-createrefsignal)
 - [`useRefSignalEffect` vs `useRefSignalRender`](#userefsignaleffect-vs-userefsignalrender)
 - [`notify()` vs `notifyUpdate()`](#notify-vs-notifyupdate)
+- [Pulse signals — clocks with tick-context metadata](#pulse-signals--clocks-with-tick-context-metadata)
 - [Signal lifetime](#signal-lifetime)
 
 ---
@@ -51,6 +52,14 @@ Both fire all subscribers. The difference is whether `lastUpdated` changes:
 - **`notify()`** — fires subscribers only. `lastUpdated` is unchanged, so `useRefSignalRender` does **not** re-render. Only `useRefSignalEffect` listeners run.
 
 This distinction matters: `useRefSignalRender` watches `lastUpdated` via `useSyncExternalStore`. If you want to drive a side effect (canvas draw) but never trigger a React re-render, use `notify()`. If you also need components to re-render, use `update()` or `notifyUpdate()`.
+
+---
+
+## Pulse signals — clocks with tick-context metadata
+
+A [`PulseRefSignal`](pulse.md) is a self-firing read-only signal: `.current` advances to `performance.now()` on a schedule, subscribers fire each tick, the timer is lazy (runs only while at least one subscriber is attached). Conceptually it's a clock primitive — closer to `createComputedRefSignal` than to `RefSignal`, with time playing the role of a dependency.
+
+It also exposes `dt`, `tick`, and `elapsed` alongside `.current`. These look like parallel reactive state but they aren't: you don't `watch(loop.dt, …)`. Read them as **tick-context metadata** — values coherent with `.current` *at the moment subscribers fire*, like `event.timeStamp` inside a DOM event handler. The reactive surface is still `.current`; the metadata rides along for game/sim code that wants `dt` without writing the bookkeeping.
 
 ---
 

--- a/docs/decision-tree.md
+++ b/docs/decision-tree.md
@@ -1,6 +1,6 @@
 # Decision Tree
 
-← [Back to README](../README.md) · [API Reference](api.md) · [Concepts](concepts.md) · [Patterns](patterns.md)
+← [Back to README](../README.md) · [API Reference](api.md) · [Concepts](concepts.md) · [Patterns](patterns.md) · [Pulse](pulse.md)
 
 ---
 
@@ -14,6 +14,7 @@
 - [8. Context / Shared State](#8-context--shared-state)
 - [9. Persistence](#9-persistence)
 - [10. Cross-tab Broadcast](#10-cross-tab-broadcast)
+- [11. Periodic Firing — Clocks, Loops, Heartbeats](#11-periodic-firing--clocks-loops-heartbeats)
 
 ---
 
@@ -278,3 +279,35 @@ flowchart TD
 
     B --> H["Compose with persist:\nbroadcast(persist(factory, persistOpts), broadcastOpts)"]
 ```
+
+---
+
+## 11. Periodic Firing — Clocks, Loops, Heartbeats
+
+> Pulse signals are self-firing. `.current` is `performance.now()` at the last tick. Lazy: the timer only runs while at least one subscriber is attached. See [Pulse](pulse.md) for narrative and recipes.
+
+```mermaid
+flowchart TD
+    Q1{"Do you need a signal that fires itself on a schedule?"}
+    Q1 -->|No| Done0["You probably want plain createRefSignal / useRefSignal"]
+    Q1 -->|Yes| Q2{"Where are you creating it?"}
+
+    Q2 -->|"Inside a React component"| A["usePulseRefSignal(rate)"]
+    Q2 -->|"Module scope / context factory / outside React"| B["createPulseRefSignal(rate)\n→ remember to call .dispose() if you own the lifetime"]
+
+    A & B --> Q3{"What cadence?"}
+    Q3 -->|"Frame-aligned, paused on hidden tabs (animation, game loops)"| F["'60fps' / '30fps' — RAF driver"]
+    Q3 -->|"Time-based, must keep firing on hidden tabs (clocks, polling, heartbeats)"| M["'1000ms' or 1000 — setInterval driver"]
+
+    F & M --> Q4{"Multiple components need the same tick stream?"}
+    Q4 -->|"No — single consumer"| Done1[Done]
+    Q4 -->|"Yes — share one timer across many components"| P["Provide via context:\nN consumers, one timer, perfect sync.\nSee pulse.md → Shared tick via provider."]
+
+    P --> Done1
+
+    Done1 --> Q5{"Do you also want to persist or broadcast something on this cadence?"}
+    Q5 -->|No| End[Done]
+    Q5 -->|"Yes — autosave, cross-tab tick, etc."| W["Two signals, composed at the consumer:\n- a non-pulse signal carries the data and has persist/broadcast\n- the pulse signal drives a subscriber that reads/writes the data signal\n\nDO NOT put a PulseRefSignal inside a persist()- or broadcast()-wrapped store —\nthe value is performance.now() and is meaningless to serialize / send across tabs."]
+    W --> End
+```
+

--- a/docs/imperative-renderers.md
+++ b/docs/imperative-renderers.md
@@ -1,6 +1,6 @@
 # Signals driving imperative renderers
 
-← [Back to README](../README.md) · [Concepts](concepts.md) · [API Reference](api.md) · [Patterns](patterns.md)
+← [Back to README](../README.md) · [Concepts](concepts.md) · [API Reference](api.md) · [Patterns](patterns.md) · [Pulse](pulse.md)
 
 ---
 

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -1,6 +1,6 @@
 # Patterns
 
-← [Back to README](../README.md) · [Concepts](concepts.md) · [API Reference](api.md) · [Imperative renderers](imperative-renderers.md) · [Broadcast](broadcast.md)
+← [Back to README](../README.md) · [Concepts](concepts.md) · [API Reference](api.md) · [Imperative renderers](imperative-renderers.md) · [Pulse](pulse.md) · [Broadcast](broadcast.md)
 
 ---
 
@@ -15,6 +15,7 @@
 - [High-frequency data with divergent consumers](#high-frequency-data-with-divergent-consumers)
 - [Filtered renders at a threshold](#filtered-renders-at-a-threshold)
 - [Module-scope signals and debounced consumers](#module-scope-signals-and-debounced-consumers)
+- [Shared pulse via provider — one timer, many components](#shared-pulse-via-provider--one-timer-many-components)
 
 ---
 
@@ -810,3 +811,45 @@ function VolumeChart() {
 `btcPrice` and `btcVolume` are plain module-level constants. `OrderManager`, `PriceTicker`, and `VolumeChart` can live in completely unrelated parts of the component tree — they share the signal reference directly, not through a React context. Module-scope signals are the right choice when the data source is global and long-lived and no factory logic is needed.
 
 `debounce: 300, maxWait: 1000` is the correct shape for expensive consumers: defer work while updates are frequent, but never fall more than one second behind on a sustained stream.
+
+---
+
+## Shared pulse via provider — one timer, many components
+
+This is the pattern that makes [`PulseRefSignal`](pulse.md) more than syntactic sugar over `setInterval`. It eliminates a real architectural cost: when many components need the same time-driven update, the naive solution is one `setInterval` per component — N timers, each with its own drift, each cleaning up on unmount, each re-rendering its component on a slightly different wall-clock instant. Cumulative cascade: cells flip from "5 minutes ago" to "6 minutes ago" at staggered moments; the eye notices.
+
+A pulse signal provided once, consumed many times, gives you **one** timer (lazily started when the first consumer mounts), perfectly synchronized fires, zero drift between consumers.
+
+```tsx
+import { createContext, useContext, type ReactNode } from 'react';
+import {
+  usePulseRefSignal,
+  useRefSignalRender,
+  type PulseRefSignal,
+} from 'react-refsignal';
+
+const NowContext = createContext<PulseRefSignal | null>(null);
+
+export function NowProvider({ children }: { children: ReactNode }) {
+  const now = usePulseRefSignal('60000ms');
+  return <NowContext.Provider value={now}>{children}</NowContext.Provider>;
+}
+
+export function useNow(): PulseRefSignal {
+  const now = useContext(NowContext);
+  if (!now) throw new Error('useNow must be used inside NowProvider');
+  return now;
+}
+
+function RelativeTime({ at }: { at: number }) {
+  const now = useNow();
+  useRefSignalRender([now]);
+  return <time>{formatAgo(at, now.current)}</time>;
+}
+```
+
+Mount fifty `<RelativeTime />` cells inside a `<NowProvider>`; you get fifty subscribers on **one** timer. Unmount them all and the timer stops automatically — no orchestration, no cleanup to forget. Re-mount any of them and the timer restarts from a fresh session.
+
+The same shape composes at any cadence: a `<TickProvider rate="60fps">` for animation work, a `<HeartbeatProvider rate="30000ms">` for connection pings, a `<NowProvider rate="60000ms">` for relative timestamps. One timer per cadence, regardless of how many consumers attach.
+
+> **Don't put the pulse signal inside a persisted or broadcasted store.** The pulse value is `performance.now()` — bound to this document's `performance.timeOrigin` and meaningless to serialize or transport. Provide it adjacent to such stores instead. See [pulse.md → What pulse can't compose with](pulse.md#what-pulse-cant-compose-with).

--- a/docs/persist.md
+++ b/docs/persist.md
@@ -1,6 +1,6 @@
 # Persist
 
-← [Back to README](../README.md) · [API Reference](api.md) · [Patterns](patterns.md) · [Broadcast](broadcast.md)
+← [Back to README](../README.md) · [API Reference](api.md) · [Patterns](patterns.md) · [Pulse](pulse.md) · [Broadcast](broadcast.md)
 
 ---
 

--- a/docs/pulse.md
+++ b/docs/pulse.md
@@ -1,0 +1,377 @@
+# Pulse
+
+← [Back to README](../README.md) · [API Reference](api.md) · [Concepts](concepts.md) · [Patterns](patterns.md) · [Decision Tree](decision-tree.md)
+
+---
+
+A **pulse signal** is a signal that fires on a schedule. `.current` is `performance.now()` at the last tick; subscribers run; computed signals downstream recompute. There is no `setInterval`-in-`useEffect` to write, no cleanup to forget, no timer to coordinate across components.
+
+It replaces three patterns in one primitive:
+
+1. The classic `useEffect(() => { const id = setInterval(...); return () => clearInterval(id); }, [])` dance — declarative now.
+2. The "force re-render every minute so 'X ago' updates" pattern — one shared `now` signal, scoped subscribers, no global re-renders.
+3. The hand-rolled animation loop — `dt`/`tick`/`elapsed` available without bookkeeping.
+
+- [Quick start](#quick-start)
+- [The shape of a pulse signal](#the-shape-of-a-pulse-signal)
+- [Lifecycle](#lifecycle)
+- [Drivers — `setInterval` vs `requestAnimationFrame`](#drivers--setinterval-vs-requestanimationframe)
+- [Reactive cadences with `updatePulse`](#reactive-cadences-with-updatepulse)
+- [Recipes](#recipes)
+  - [Live "X ago" timestamps](#live-x-ago-timestamps)
+  - [Auth-token refresh](#auth-token-refresh)
+  - [Game loop with `dt`](#game-loop-with-dt)
+  - [Shared tick via provider — one timer, many components](#shared-tick-via-provider--one-timer-many-components)
+  - [Heartbeat that reacts to game state](#heartbeat-that-reacts-to-game-state)
+  - [Polling with exponential backoff](#polling-with-exponential-backoff)
+- [What pulse can't compose with](#what-pulse-cant-compose-with)
+- [SSR](#ssr)
+
+---
+
+## Quick start
+
+```ts
+import { createPulseRefSignal, usePulseRefSignal } from 'react-refsignal';
+
+// Outside React — module scope, context factories, anywhere.
+const now      = createPulseRefSignal('1000ms'); // every second
+const loop     = createPulseRefSignal('60fps');  // frame-locked
+const everyHalf = createPulseRefSignal(500);     // number — same as '500ms'
+
+// Inside React — lifetime tied to the component.
+function Clock() {
+  const now = usePulseRefSignal('1000ms');
+  useRefSignalRender([now]);
+  return <span>{new Date().toLocaleTimeString()}</span>;
+}
+```
+
+Three accepted rate formats:
+
+| Form | Driver | Note |
+|---|---|---|
+| `number` (e.g. `100`) | `setInterval` | ms — same as the `'Nms'` form |
+| `'Nms'` (e.g. `'250ms'`, `'16.67ms'`) | `setInterval` | ms with explicit unit |
+| `'Nfps'` (e.g. `'60fps'`, `'30fps'`) | `requestAnimationFrame` | frame-aligned, paused on hidden tabs |
+
+Decimals are accepted in both string forms.
+
+---
+
+## The shape of a pulse signal
+
+`PulseRefSignal` extends `ReadonlyRefSignal<number>` with three additional readonly fields — `dt`, `tick`, `elapsed`. They look like parallel reactive state, but they aren't: you can't `watch(loop.dt, …)`. They are **tick-context metadata** — values coherent with `.current` *at the moment subscribers fire*, like `event.timeStamp` inside a DOM event handler.
+
+```ts
+const loop = createPulseRefSignal('60fps');
+
+loop.subscribe(() => {
+  loop.current; // performance.now() at this tick — the reactive value
+  loop.dt;      // ms since previous tick — context for THIS fire
+  loop.tick;    // 1, 2, 3, …
+  loop.elapsed; // ms since first tick of this session
+});
+```
+
+The reactive surface is still `.current`. The metadata rides along.
+
+| Field | Meaning |
+|---|---|
+| `current` | `performance.now()` at the most recent tick. Reactive — bumps `lastUpdated`, fires subscribers. |
+| `dt` | Milliseconds since the previous tick. `0` between sessions; on the first tick, `0` (or the time since timer start, whichever the implementation deems honest — see [Lifecycle](#lifecycle)). |
+| `tick` | Number of ticks fired in the current session. `0` before the first fire, increments by `1` each tick. |
+| `elapsed` | Milliseconds since the first tick of the current session. `0` until the second tick. |
+
+> **Why a number, not an object?**  Most use cases (clocks, "X ago", token TTLs) want a primitive. Forcing every reader to write `now.current.now` to get the time would tax the dominant case to make game-loop code marginally cleaner. The metadata-on-the-side shape pays the cost where the cost lands: game/sim code, where `loop.dt` is one identifier instead of one destructure.
+
+---
+
+## Lifecycle
+
+Pulse signals are **lazy**. The timer only runs while the signal has at least one subscriber:
+
+- `0 → 1` subscriber transition → timer starts; `dt`/`tick`/`elapsed` reset to `0`.
+- `1 → 0` subscriber transition → timer stops.
+- `.dispose()` (only on `createPulseRefSignal`'s return; the React hook owns its own disposal) → timer stops, subscribers cleared.
+
+**Session reset**, not accumulating state. If subscribers go to zero and back — e.g., a component using the signal unmounts and a sibling remounts — the next session starts fresh: `tick = 0`, `elapsed = 0`. The first new tick's `dt` is measured from the new session start, not from whenever the previous session stopped. Otherwise an idle gap would manifest as a single huge `dt` spike — the wrong thing for game/sim code, and meaningless for clocks.
+
+A pulse signal that is never subscribed to never installs a timer. It costs nothing.
+
+---
+
+## Drivers — `setInterval` vs `requestAnimationFrame`
+
+The rate format picks the driver:
+
+- **`'Nfps'` → `requestAnimationFrame`.** Frame-aligned. Pauses on hidden tabs (the browser stops calling RAF). Capped by the display refresh rate — requesting `'120fps'` on a 60Hz display gives you 60. Use this for game loops, animation, anything that should be visible-time-aware.
+- **`number` / `'Nms'` → `setInterval`.** Continues firing on hidden tabs (subject to browser's background-tab throttling). Drift may accumulate over long sessions. Use this for clocks, polling, heartbeats, token refresh — anything where missing a tick on a hidden tab would be a bug, not a feature.
+
+You'd reach for `'Nms'` over a number when you want the unit to show up in code review (`'250ms'` reads as a duration; `250` could be anything).
+
+---
+
+## Reactive cadences with `updatePulse`
+
+The rate isn't only configuration — it's also data. A heartbeat speeds up under stress and slows at rest. Polling backs off when the server is slow. Frame rate adapts to a perf budget. For all of these, the cadence itself flows through the reactive system. `updatePulse(newRate)` is the method that lets pulse signals participate.
+
+```ts
+const heartbeat = createPulseRefSignal('1000ms');
+heartbeat.updatePulse('500ms'); // double the rate
+```
+
+Semantics:
+
+- **Validates the new rate** — same parser as the constructor; throws on invalid. The timer is not disturbed if validation fails.
+- **Continuity preserved** — `tick` and `elapsed` keep accumulating across the rate change. Only `lastTickTime` is reset, so the next `dt` is measured from the rate-change moment rather than spanning the restart at the old cadence.
+- **Idle store** — if no subscribers are attached, `updatePulse` just stores the new rate. The next `0 → 1` subscriber transition triggers the usual full-session reset and uses the new rate.
+- **Driver may switch** — `updatePulse('1000ms' → '60fps')` swaps the `setInterval`-driven loop for a `requestAnimationFrame` loop transparently.
+
+> **In React, drive `updatePulse` with `useRefSignalEffect`, not `useEffect`.** A `useEffect(..., [rate.current])` only re-evaluates when the *component* re-renders — but signals updating doesn't trigger re-renders by default, so the effect fires once on mount and never again. `useRefSignalEffect` subscribes to the signal directly:
+>
+> ```ts
+> useRefSignalEffect(() => {
+>   pulse.updatePulse(rateSignal.current);
+> }, [rateSignal]);
+> ```
+
+> **Cycle warning** — pulse can now participate in reactive feedback loops (a tick updates X, X drives the rate, the new rate updates the pulse). Same shape as any cycle in the reactive graph: it's the user's responsibility to ensure convergence (idempotent rate functions, dampening, hysteresis bands).
+
+---
+
+## Recipes
+
+### Live "X ago" timestamps
+
+The canonical case. Every social/feed/dashboard app has it. The naive solution forces a global `setInterval(forceUpdate, 60_000)` at the app root, re-rendering everything once a minute. With pulse, you have a `now` signal pulsing once a minute, and only the components reading it re-render — exactly when needed, never otherwise.
+
+```tsx
+import { createPulseRefSignal, useRefSignalRender } from 'react-refsignal';
+
+// Module-scope: one signal for the whole app, lazily started by the first reader.
+const now = createPulseRefSignal('60000ms'); // every minute
+
+function RelativeTime({ at }: { at: number }) {
+  useRefSignalRender([now]);
+  return <time>{formatAgo(at, now.current)}</time>;
+}
+```
+
+Mount fifty `<RelativeTime />` cells; you get fifty subscribers on one `setInterval`. Unmount them all and the timer stops. There is no global re-render — only the `<RelativeTime />` instances re-render, every minute, in lockstep.
+
+### Auth-token refresh
+
+```ts
+import { createPulseRefSignal } from 'react-refsignal';
+
+// Refresh four minutes before a five-minute token expires.
+const refreshTick = createPulseRefSignal(4 * 60 * 1000);
+refreshTick.subscribe(() => {
+  void refreshAuthToken();
+});
+```
+
+That's it. No `useEffect`, no stale-closure ref dance, no cleanup forgotten on a route change. The subscription lives where the auth code lives.
+
+### Game loop with `dt`
+
+```tsx
+function Particles() {
+  const loop = usePulseRefSignal('60fps');
+
+  useRefSignalEffect(() => {
+    advancePhysics(loop.dt);   // ms since previous tick
+    if (loop.tick % 60 === 0) emitDebugFrame();
+    drawScene(canvasRef.current!);
+  }, [loop]);
+
+  return <canvas ref={canvasRef} />;
+}
+```
+
+`loop.dt` is the delta you'd normally compute by tracking `performance.now()` and a `last` ref. `loop.tick` gates effects that should happen every Nth frame. `loop.elapsed` drives time-based easing without a separate clock signal.
+
+For variable-step physics this is what you want; for fixed-step physics you'd accumulate `loop.dt` and step at a fixed rate inside the effect. Pulse gives you the heartbeat; the simulation strategy is yours.
+
+### Shared tick via provider — one timer, many components
+
+This is the architectural pattern that elevates pulse from "syntactic sugar over `setInterval`" to a primitive that changes how you organize time-driven UI.
+
+Without it, fifty "X ago" cells means fifty `setInterval` instances, each with its own drift, each cleaning up on unmount, each re-rendering its component once a minute on a slightly different wall-clock instant. Cumulative cascade: cells flip from "5 minutes ago" to "6 minutes ago" at staggered moments; the eye notices.
+
+With it, fifty cells means **one** timer (lazily started when the first cell mounts), perfectly synchronized fires, zero drift between them.
+
+```tsx
+import { createContext, useContext, type ReactNode } from 'react';
+import {
+  usePulseRefSignal,
+  useRefSignalRender,
+  type PulseRefSignal,
+} from 'react-refsignal';
+
+const NowContext = createContext<PulseRefSignal | null>(null);
+
+export function NowProvider({ children }: { children: ReactNode }) {
+  const now = usePulseRefSignal('60000ms');
+  return <NowContext.Provider value={now}>{children}</NowContext.Provider>;
+}
+
+export function useNow(): PulseRefSignal {
+  const now = useContext(NowContext);
+  if (!now) throw new Error('useNow must be used inside NowProvider');
+  return now;
+}
+
+function RelativeTime({ at }: { at: number }) {
+  const now = useNow();
+  useRefSignalRender([now]);
+  return <time>{formatAgo(at, now.current)}</time>;
+}
+```
+
+Wrap the relevant subtree in `<NowProvider>` and every consumer shares one timer. The timer doesn't even start until at least one consumer subscribes, and stops if they all leave — automatic, no orchestration.
+
+Same shape works at any cadence: a `<TickProvider rate="60fps">` for animation, a `<HeartbeatProvider>` for connection pings. One timer per cadence, regardless of how many components need it.
+
+### Heartbeat that reacts to game state
+
+The cadence is data: heart-beats-per-minute is driven by stamina and danger signals. `updatePulse` makes the pulse signal a first-class participant in the reactive graph instead of a fixed clock.
+
+```tsx
+import {
+  useRefSignal,
+  useRefSignalMemo,
+  useRefSignalEffect,
+  usePulseRefSignal,
+  type PulseRate,
+} from 'react-refsignal';
+
+function Heart() {
+  const stamina = useRefSignal(100);
+  const danger = useRefSignal(0);
+
+  // Computed signal: derives the desired cadence from gameplay state.
+  const heartRate = useRefSignalMemo(
+    () => `${msPerBeat(stamina.current, danger.current)}ms` as PulseRate,
+    [stamina, danger],
+  );
+
+  // The pulse — initial cadence is the resting rate; updatePulse is what
+  // wires the cadence to the computed.
+  const heartbeat = usePulseRefSignal('1000ms');
+
+  // Direct signal subscription — no React render needed, no stale closures.
+  useRefSignalEffect(() => {
+    heartbeat.updatePulse(heartRate.current);
+  }, [heartRate]);
+
+  // Drive a visual pulse on each beat.
+  useRefSignalEffect(() => {
+    pulseAnimation.fire();
+  }, [heartbeat]);
+
+  return <HeartIcon ref={pulseAnimation.ref} />;
+}
+```
+
+Two signals, one computed, two effects, no `setInterval`-in-`useEffect`, no stale-closure dance, no re-renders. The whole behavior is in the reactive graph — change the model (`stamina.update(50)`) and the visuals follow.
+
+### Polling with exponential backoff
+
+Backoff is a domain pattern — polling, retry — built on top of `updatePulse`. Pulse stays minimal; the backoff lives in user-land and gets ten lines of code.
+
+```tsx
+import { useRef } from 'react';
+import { usePulseRefSignal, type PulseRefSignal } from 'react-refsignal';
+
+interface BackoffPulse {
+  pulse: PulseRefSignal;
+  onError: () => void;
+  onSuccess: () => void;
+}
+
+function useBackoffPulse(
+  initialMs: number,
+  { maxMs, factor = 2 }: { maxMs: number; factor?: number },
+): BackoffPulse {
+  const pulse = usePulseRefSignal(initialMs);
+  const currentMs = useRef(initialMs);
+  return {
+    pulse,
+    onError: () => {
+      currentMs.current = Math.min(currentMs.current * factor, maxMs);
+      pulse.updatePulse(currentMs.current);
+    },
+    onSuccess: () => {
+      currentMs.current = initialMs;
+      pulse.updatePulse(currentMs.current);
+    },
+  };
+}
+
+function FeedPoller() {
+  const { pulse, onError, onSuccess } = useBackoffPulse(1000, { maxMs: 30_000 });
+
+  useRefSignalEffect(() => {
+    void fetch('/api/feed')
+      .then((r) => (r.ok ? onSuccess() : onError()))
+      .catch(onError);
+  }, [pulse]);
+
+  return null;
+}
+```
+
+On error, the polling interval doubles up to a 30s ceiling. On success, it resets. The library exposes nothing new — the recipe is the composition. Add jitter, max-attempts, abort-on-unmount as the use case demands; none of it needs to grow the core API.
+
+---
+
+## What pulse can't compose with
+
+The TypeScript signature of `createPulseRefSignal` doesn't expose `persist` or `broadcast` options. They're absent intentionally:
+
+- **Pulse + persist** — the value being persisted is `performance.now()`, which is reference-frame-bound to the current document (`performance.timeOrigin`). On a future page load it's interpreted in a different reference frame and is meaningless. Persisting it would flood storage with useless writes. *If you want autosave-on-a-cadence, that's a different pattern: a draft signal with `persist`, a separate pulse signal whose subscriber calls `saveToServer(draft.current)`. Two signals, composed at the consumer.*
+- **Pulse + broadcast** — same reference-frame issue (each tab has its own `timeOrigin`, so the broadcast value is unintelligible to other tabs), plus a many-to-many tick storm where every tab sends its own ticks to every other tab. The "shared tick across tabs" use case exists but requires leader election, which isn't this primitive.
+
+If you need either of these compositions, the pattern is "two signals, composed at the consumer level" — not enhancers stacked on a pulse signal.
+
+### A pulse signal *inside* a persisted or broadcast store has the same problem
+
+The signal-level type guard does **not** extend through stores. A `PulseRefSignal` placed inside a `persist()`-wrapped or `broadcast()`-wrapped store factory compiles cleanly and breaks at runtime in the same two ways:
+
+```ts
+// ✗ Don't.
+const factory = persist(
+  () => ({
+    cursor: createRefSignal({ x: 0, y: 0 }),
+    now:    createPulseRefSignal('1000ms'), // every tick → store snapshot changes → flush
+  }),
+  { key: 'session' },
+);
+```
+
+Every tick is a state change in the store, so the enhancer fires on every tick: persist flushes the snapshot to storage, broadcast sends the whole thing to other tabs. Both operate on `performance.now()`-shaped data that is meaningless outside this document. The pulse signal being typed as `ReadonlyRefSignal` at the surface doesn't protect it — at runtime, broadcast adapters call `.update()` directly on the underlying object, so foreign tabs happily overwrite a local tab's `.current` with their own `performance.now()` values.
+
+The rule generalizes: **pulse signals do not belong in any container that serializes or transports their value**. The composition that does work is:
+
+- pulse signal **adjacent to** the persisted / broadcasted store, not inside it
+- pulse subscribers read from / write to that store as needed
+
+```tsx
+<NowProvider>                       {/* PulseRefSignal */}
+  <SessionStoreProvider>            {/* broadcast / persist'd store */}
+    <App />
+  </SessionStoreProvider>
+</NowProvider>
+```
+
+Components that need both pull from both. The pulse drives effects that read or write the persisted store — but pulse itself never enters it.
+
+---
+
+## SSR
+
+`createPulseRefSignal` and `usePulseRefSignal` construct cleanly on the server: `.current` initializes to `performance.now()` (Node provides it), `dt`/`tick`/`elapsed` are `0`. No timer is installed when `typeof window === 'undefined'`. Subscribing on the server is a no-op for tick purposes — the listener registers, but no tick will fire.
+
+On hydration, the timer starts naturally on the first client-side subscription. There is no manual hydration step.

--- a/src/hooks/usePulseRefSignal.test.ts
+++ b/src/hooks/usePulseRefSignal.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act } from 'react';
+import { renderHook } from '../test-utils/renderHook';
+import { usePulseRefSignal } from './usePulseRefSignal';
+
+describe('usePulseRefSignal', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns a stable signal across renders', () => {
+    const { result, rerender } = renderHook(() => usePulseRefSignal(100));
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+
+  it('initializes with current = performance.now() and zero counters', () => {
+    const before = performance.now();
+    const { result } = renderHook(() => usePulseRefSignal(100));
+    const after = performance.now();
+    expect(result.current.current).toBeGreaterThanOrEqual(before);
+    expect(result.current.current).toBeLessThanOrEqual(after);
+    expect(result.current.tick).toBe(0);
+    expect(result.current.dt).toBe(0);
+    expect(result.current.elapsed).toBe(0);
+  });
+
+  it('drives subscribers on its cadence', () => {
+    const { result } = renderHook(() => usePulseRefSignal(100));
+    const listener = jest.fn();
+    act(() => {
+      result.current.subscribe(listener);
+    });
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(result.current.tick).toBe(1);
+  });
+
+  it('disposes the signal on unmount — timer stops firing', () => {
+    const { result, unmount } = renderHook(() => usePulseRefSignal(100));
+    const listener = jest.fn();
+    act(() => {
+      result.current.subscribe(listener);
+    });
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unmount();
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    // No further fires after unmount.
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes updatePulse — rate can be changed dynamically post-mount', () => {
+    const { result } = renderHook(() => usePulseRefSignal(100));
+    const listener = jest.fn();
+    act(() => {
+      result.current.subscribe(listener);
+    });
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.updatePulse(500);
+    });
+    // Old 100ms cadence is gone.
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    expect(listener).toHaveBeenCalledTimes(1);
+    // New 500ms cadence fires.
+    act(() => {
+      jest.advanceTimersByTime(400);
+    });
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores rate changes after mount (mount-time option)', () => {
+    const { result, rerender } = renderHook(
+      ({ rate }: { rate: number }) => usePulseRefSignal(rate),
+      { initialProps: { rate: 100 } },
+    );
+    const first = result.current;
+    rerender({ rate: 500 });
+    expect(result.current).toBe(first);
+
+    const listener = jest.fn();
+    act(() => {
+      result.current.subscribe(listener);
+    });
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    // Original 100ms cadence still in effect.
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/usePulseRefSignal.ts
+++ b/src/hooks/usePulseRefSignal.ts
@@ -1,0 +1,44 @@
+import { useEffect, useMemo } from 'react';
+import { createPulseRefSignal, PulseRate, PulseRefSignal } from '../pulse';
+
+/**
+ * React hook companion to {@link createPulseRefSignal}.
+ *
+ * Returns a stable {@link PulseRefSignal} created on first render and disposed
+ * on unmount. Subsequent changes to `rate` are ignored — the cadence is
+ * captured at mount time, mirroring the mount-time-options convention used by
+ * {@link useRefSignal}.
+ *
+ * The signal does not expose `.dispose()` to the caller — React owns its
+ * lifetime. Subscribers attached during render (e.g. via `useRefSignalEffect`)
+ * are torn down by their own cleanup, and the signal itself is disposed when
+ * the component unmounts.
+ *
+ * @example
+ * const now = usePulseRefSignal('1000ms');
+ * useRefSignalEffect(now, () => setLabel(formatAgo(post.createdAt, now.current)));
+ *
+ * @example
+ * // Provide once, share many — N components consume the same tick stream
+ * // through one timer.
+ * const TickContext = createRefSignalContext<PulseRefSignal>();
+ *
+ * function Provider({ children }: { children: React.ReactNode }) {
+ *   const tick = usePulseRefSignal('60fps');
+ *   return <TickContext.Provider value={tick}>{children}</TickContext.Provider>;
+ * }
+ */
+export function usePulseRefSignal(rate: PulseRate): PulseRefSignal {
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- pulse rate is captured at mount, like other useRefSignal options
+  const signal = useMemo(() => createPulseRefSignal(rate), []);
+
+  useEffect(
+    () => () => {
+      signal.dispose();
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- signal is stable for the component lifetime
+    [],
+  );
+
+  return signal;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from './hooks/useRefSignalEffect';
 export * from './hooks/useRefSignalMemo';
 export * from './hooks/useRefSignalRender';
 export * from './hooks/useRefSignalFollow';
+export * from './hooks/usePulseRefSignal';
 export type {
   Listener,
   RefSignal,
@@ -28,6 +29,8 @@ export {
   createComputedRefSignal,
   watch,
 } from './refsignal';
+export { createPulseRefSignal } from './pulse';
+export type { PulseRate, PulseRefSignal } from './pulse';
 // Deprecated factory re-exported for backward compatibility.
 export {
   // eslint-disable-next-line @typescript-eslint/no-deprecated

--- a/src/pulse.ssr.test.ts
+++ b/src/pulse.ssr.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment node
+ *
+ * Runs in pure Node where `typeof window === 'undefined'`, exercising the
+ * SSR guard inside `createPulseRefSignal`. Construction must succeed (so the
+ * signal can be hydrated on the client), but no timer should be installed.
+ */
+
+import { createPulseRefSignal } from './pulse';
+
+describe('createPulseRefSignal SSR guard', () => {
+  it('window is undefined in this environment (sanity)', () => {
+    expect(typeof window).toBe('undefined');
+  });
+
+  it('constructs a usable signal without starting any timer', () => {
+    const setIntervalSpy = jest.spyOn(global, 'setInterval');
+    try {
+      const s = createPulseRefSignal(100);
+      expect(typeof s.current).toBe('number');
+      expect(s.tick).toBe(0);
+      expect(s.dt).toBe(0);
+      expect(s.elapsed).toBe(0);
+
+      const listener = jest.fn();
+      s.subscribe(listener);
+      // Even with a subscriber, no timer should have been installed.
+      expect(setIntervalSpy).not.toHaveBeenCalled();
+      // And the listener should never fire on its own.
+      expect(listener).not.toHaveBeenCalled();
+
+      s.unsubscribe(listener);
+      expect(() => {
+        s.dispose();
+      }).not.toThrow();
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
+  });
+
+  it('does not install a RAF loop for fps notation either', () => {
+    const s = createPulseRefSignal('60fps');
+    const listener = jest.fn();
+    expect(() => {
+      s.subscribe(listener);
+    }).not.toThrow();
+    expect(listener).not.toHaveBeenCalled();
+    s.dispose();
+  });
+});

--- a/src/pulse.test.ts
+++ b/src/pulse.test.ts
@@ -1,0 +1,583 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { createPulseRefSignal } from './pulse';
+import { setupRafMock } from './test-utils/raf';
+
+describe('createPulseRefSignal', () => {
+  describe('rate parsing', () => {
+    it('accepts a positive number (interpreted as ms)', () => {
+      const s = createPulseRefSignal(100);
+      expect(typeof s.current).toBe('number');
+      s.dispose();
+    });
+
+    it("accepts 'Nms' strings", () => {
+      const s = createPulseRefSignal('250ms');
+      expect(typeof s.current).toBe('number');
+      s.dispose();
+    });
+
+    it("accepts 'Nfps' strings", () => {
+      const s = createPulseRefSignal('60fps');
+      expect(typeof s.current).toBe('number');
+      s.dispose();
+    });
+
+    it('accepts decimal ms and fps', () => {
+      const a = createPulseRefSignal('16.67ms');
+      const b = createPulseRefSignal('59.94fps');
+      a.dispose();
+      b.dispose();
+    });
+
+    it('rejects zero', () => {
+      expect(() => createPulseRefSignal(0)).toThrow(/Invalid pulse rate/);
+    });
+
+    it('rejects negatives', () => {
+      expect(() => createPulseRefSignal(-100)).toThrow(/Invalid pulse rate/);
+    });
+
+    it('rejects NaN', () => {
+      expect(() => createPulseRefSignal(Number.NaN)).toThrow(
+        /Invalid pulse rate/,
+      );
+    });
+
+    it('rejects Infinity', () => {
+      expect(() => createPulseRefSignal(Number.POSITIVE_INFINITY)).toThrow(
+        /Invalid pulse rate/,
+      );
+    });
+
+    it('rejects unitless / unknown-unit strings', () => {
+      expect(() => createPulseRefSignal('60' as never)).toThrow(
+        /Invalid pulse rate/,
+      );
+      expect(() => createPulseRefSignal('60s' as never)).toThrow(
+        /Invalid pulse rate/,
+      );
+      expect(() => createPulseRefSignal('hello' as never)).toThrow(
+        /Invalid pulse rate/,
+      );
+    });
+
+    it("rejects '0fps' and '0ms'", () => {
+      expect(() => createPulseRefSignal('0fps' as never)).toThrow(
+        /fps must be positive/,
+      );
+      expect(() => createPulseRefSignal('0ms' as never)).toThrow(
+        /ms must be positive/,
+      );
+    });
+  });
+
+  describe('initial state (no ticks yet)', () => {
+    it('current is performance.now() at creation', () => {
+      const before = performance.now();
+      const s = createPulseRefSignal(100);
+      const after = performance.now();
+      expect(s.current).toBeGreaterThanOrEqual(before);
+      expect(s.current).toBeLessThanOrEqual(after);
+      s.dispose();
+    });
+
+    it('dt, tick, elapsed are all zero', () => {
+      const s = createPulseRefSignal(100);
+      expect(s.dt).toBe(0);
+      expect(s.tick).toBe(0);
+      expect(s.elapsed).toBe(0);
+      s.dispose();
+    });
+
+    it('lastUpdated starts at 0', () => {
+      const s = createPulseRefSignal(100);
+      expect(s.lastUpdated).toBe(0);
+      s.dispose();
+    });
+  });
+
+  describe('lazy lifecycle (interval driver)', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('does not fire while there are no subscribers', () => {
+      const s = createPulseRefSignal(100);
+      jest.advanceTimersByTime(1000);
+      expect(s.tick).toBe(0);
+      s.dispose();
+    });
+
+    it('starts firing after first subscriber', () => {
+      const s = createPulseRefSignal(100);
+      const listener = jest.fn();
+      s.subscribe(listener);
+      jest.advanceTimersByTime(100);
+      expect(listener).toHaveBeenCalledTimes(1);
+      s.dispose();
+    });
+
+    it('uses one timer for many subscribers', () => {
+      const setIntervalSpy = jest.spyOn(global, 'setInterval');
+      const s = createPulseRefSignal(100);
+      s.subscribe(jest.fn());
+      s.subscribe(jest.fn());
+      s.subscribe(jest.fn());
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+      s.dispose();
+      setIntervalSpy.mockRestore();
+    });
+
+    it('keeps firing while at least one subscriber remains', () => {
+      const s = createPulseRefSignal(100);
+      const a = jest.fn();
+      const b = jest.fn();
+      s.subscribe(a);
+      s.subscribe(b);
+      s.unsubscribe(a);
+      jest.advanceTimersByTime(100);
+      expect(b).toHaveBeenCalledTimes(1);
+      s.dispose();
+    });
+
+    it('stops firing when last subscriber leaves', () => {
+      const s = createPulseRefSignal(100);
+      const a = jest.fn();
+      s.subscribe(a);
+      s.unsubscribe(a);
+      jest.advanceTimersByTime(1000);
+      expect(a).not.toHaveBeenCalled();
+      s.dispose();
+    });
+
+    it('restarts the timer on a fresh subscriber after going idle', () => {
+      const s = createPulseRefSignal(100);
+      const a = jest.fn();
+      s.subscribe(a);
+      s.unsubscribe(a);
+      s.subscribe(a);
+      jest.advanceTimersByTime(100);
+      expect(a).toHaveBeenCalledTimes(1);
+      s.dispose();
+    });
+
+    it('subscribing the same listener twice does not double-start', () => {
+      const setIntervalSpy = jest.spyOn(global, 'setInterval');
+      const s = createPulseRefSignal(100);
+      const listener = jest.fn();
+      s.subscribe(listener);
+      s.subscribe(listener); // duplicate — no transition
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+      s.dispose();
+      setIntervalSpy.mockRestore();
+    });
+
+    it('unsubscribing before any subscribe is a safe no-op', () => {
+      const s = createPulseRefSignal(100);
+      expect(() => {
+        s.unsubscribe(jest.fn());
+      }).not.toThrow();
+      jest.advanceTimersByTime(1000);
+      expect(s.tick).toBe(0);
+      s.dispose();
+    });
+
+    it('unsubscribing an unknown listener does not stop the timer', () => {
+      const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+      const s = createPulseRefSignal(100);
+      const a = jest.fn();
+      const b = jest.fn();
+      s.subscribe(a);
+      s.unsubscribe(b); // not subscribed — no transition
+      expect(clearIntervalSpy).not.toHaveBeenCalled();
+      s.dispose();
+      clearIntervalSpy.mockRestore();
+    });
+
+    it('dispose stops the timer', () => {
+      const s = createPulseRefSignal(100);
+      const a = jest.fn();
+      s.subscribe(a);
+      s.dispose();
+      jest.advanceTimersByTime(1000);
+      expect(a).not.toHaveBeenCalled();
+    });
+
+    it('dispose is safe when no timer was ever started', () => {
+      const s = createPulseRefSignal(100);
+      expect(() => {
+        s.dispose();
+      }).not.toThrow();
+    });
+
+    it('dispose is idempotent', () => {
+      const s = createPulseRefSignal(100);
+      s.subscribe(jest.fn());
+      s.dispose();
+      expect(() => {
+        s.dispose();
+      }).not.toThrow();
+    });
+  });
+
+  describe('tick semantics (interval driver)', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('updates current and bumps lastUpdated each tick', () => {
+      const s = createPulseRefSignal(100);
+      s.subscribe(jest.fn());
+      const u0 = s.lastUpdated;
+      const c0 = s.current;
+      jest.advanceTimersByTime(100);
+      expect(s.lastUpdated).toBeGreaterThan(u0);
+      expect(s.current).toBeGreaterThanOrEqual(c0);
+      const u1 = s.lastUpdated;
+      jest.advanceTimersByTime(100);
+      expect(s.lastUpdated).toBeGreaterThan(u1);
+      s.dispose();
+    });
+
+    it('tick counter increments by 1 per fire', () => {
+      const s = createPulseRefSignal(100);
+      s.subscribe(jest.fn());
+      expect(s.tick).toBe(0);
+      jest.advanceTimersByTime(100);
+      expect(s.tick).toBe(1);
+      jest.advanceTimersByTime(100);
+      expect(s.tick).toBe(2);
+      jest.advanceTimersByTime(300);
+      expect(s.tick).toBe(5);
+      s.dispose();
+    });
+
+    it('dt reflects time between ticks; elapsed accumulates from first tick', () => {
+      let nowVal = 1000;
+      const perfSpy = jest
+        .spyOn(performance, 'now')
+        .mockImplementation(() => nowVal);
+      const s = createPulseRefSignal(100);
+      s.subscribe(jest.fn());
+
+      // First tick — dt = 100 (from start time 1000 to 1100), elapsed = 0
+      nowVal = 1100;
+      jest.advanceTimersByTime(100);
+      expect(s.tick).toBe(1);
+      expect(s.dt).toBe(100);
+      expect(s.elapsed).toBe(0);
+
+      // Second tick — dt = 150, elapsed = 150 (since first tick at 1100)
+      nowVal = 1250;
+      jest.advanceTimersByTime(100);
+      expect(s.tick).toBe(2);
+      expect(s.dt).toBe(150);
+      expect(s.elapsed).toBe(150);
+
+      // Third tick — dt = 50, elapsed = 200
+      nowVal = 1300;
+      jest.advanceTimersByTime(100);
+      expect(s.tick).toBe(3);
+      expect(s.dt).toBe(50);
+      expect(s.elapsed).toBe(200);
+
+      s.dispose();
+      perfSpy.mockRestore();
+    });
+
+    it('fires every subscriber on each tick', () => {
+      const s = createPulseRefSignal(100);
+      const a = jest.fn();
+      const b = jest.fn();
+      const c = jest.fn();
+      s.subscribe(a);
+      s.subscribe(b);
+      s.subscribe(c);
+      jest.advanceTimersByTime(100);
+      expect(a).toHaveBeenCalledTimes(1);
+      expect(b).toHaveBeenCalledTimes(1);
+      expect(c).toHaveBeenCalledTimes(1);
+      s.dispose();
+    });
+
+    it('resets dt/tick/elapsed on a fresh subscribe session', () => {
+      let nowVal = 1000;
+      const perfSpy = jest
+        .spyOn(performance, 'now')
+        .mockImplementation(() => nowVal);
+      const s = createPulseRefSignal(100);
+      const a = jest.fn();
+      s.subscribe(a);
+      nowVal = 1100;
+      jest.advanceTimersByTime(100);
+      nowVal = 1200;
+      jest.advanceTimersByTime(100);
+      expect(s.tick).toBe(2);
+      expect(s.elapsed).toBe(100);
+
+      s.unsubscribe(a);
+      nowVal = 5000; // long idle gap
+
+      s.subscribe(a);
+      // Re-subscribe resets the session
+      expect(s.tick).toBe(0);
+      expect(s.elapsed).toBe(0);
+      expect(s.dt).toBe(0);
+
+      // First tick of new session: dt is measured from the (re)start, not the idle gap
+      nowVal = 5100;
+      jest.advanceTimersByTime(100);
+      expect(s.tick).toBe(1);
+      expect(s.dt).toBe(100);
+      s.dispose();
+      perfSpy.mockRestore();
+    });
+  });
+
+  describe('updatePulse', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('changes cadence on a running timer', () => {
+      const s = createPulseRefSignal(100);
+      const listener = jest.fn();
+      s.subscribe(listener);
+      jest.advanceTimersByTime(100);
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      s.updatePulse(500);
+      // The 100ms timer was cleared. Advancing 100ms should NOT fire.
+      jest.advanceTimersByTime(100);
+      expect(listener).toHaveBeenCalledTimes(1);
+      // After the new 500ms cadence elapses, it does.
+      jest.advanceTimersByTime(400);
+      expect(listener).toHaveBeenCalledTimes(2);
+      s.dispose();
+    });
+
+    it('preserves tick and elapsed across rate changes', () => {
+      let nowVal = 1000;
+      const perfSpy = jest
+        .spyOn(performance, 'now')
+        .mockImplementation(() => nowVal);
+
+      const s = createPulseRefSignal(100);
+      s.subscribe(jest.fn());
+
+      nowVal = 1100;
+      jest.advanceTimersByTime(100);
+      nowVal = 1200;
+      jest.advanceTimersByTime(100);
+      expect(s.tick).toBe(2);
+      expect(s.elapsed).toBe(100);
+
+      // Change rate — tick / elapsed should keep accumulating
+      nowVal = 1250;
+      s.updatePulse(500);
+      expect(s.tick).toBe(2);
+      expect(s.elapsed).toBe(100);
+
+      // Next tick at 500ms after rate-change baseline (1250 → 1750)
+      nowVal = 1750;
+      jest.advanceTimersByTime(500);
+      expect(s.tick).toBe(3);
+      // dt is measured from the rate-change moment, not the previous tick
+      expect(s.dt).toBe(500);
+      // elapsed reflects time since first tick (1100), continuity preserved
+      expect(s.elapsed).toBe(650);
+
+      s.dispose();
+      perfSpy.mockRestore();
+    });
+
+    it('only stores the new rate when no subscribers are attached', () => {
+      const setIntervalSpy = jest.spyOn(global, 'setInterval');
+      const s = createPulseRefSignal(100);
+      // No subscribers yet — updatePulse must not start a timer.
+      s.updatePulse(500);
+      expect(setIntervalSpy).not.toHaveBeenCalled();
+
+      // First subscriber triggers start at the new (500ms) cadence.
+      const listener = jest.fn();
+      s.subscribe(listener);
+      jest.advanceTimersByTime(100);
+      expect(listener).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(400);
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      s.dispose();
+      setIntervalSpy.mockRestore();
+    });
+
+    it('throws on invalid rate without disturbing the running timer', () => {
+      const s = createPulseRefSignal(100);
+      const listener = jest.fn();
+      s.subscribe(listener);
+
+      expect(() => {
+        s.updatePulse('nope' as never);
+      }).toThrow(/Invalid pulse rate/);
+
+      // Original 100ms cadence still active.
+      jest.advanceTimersByTime(100);
+      expect(listener).toHaveBeenCalledTimes(1);
+      s.dispose();
+    });
+
+    it('switches drivers when the format changes (interval → raf)', () => {
+      const setIntervalSpy = jest.spyOn(global, 'setInterval');
+      const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+      const s = createPulseRefSignal(100);
+      s.subscribe(jest.fn());
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+
+      // Switching to fps notation should clear the interval and install RAF.
+      // RAF isn't available in node-fake-timers; the SSR-style guard means
+      // installTimer no-ops when window is undefined — which it isn't here
+      // (jsdom env), but RAF in jsdom may be polyfilled. Rather than assert
+      // on raf internals, assert the interval was torn down.
+      s.updatePulse('60fps');
+      expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+
+      s.dispose();
+      setIntervalSpy.mockRestore();
+      clearIntervalSpy.mockRestore();
+    });
+
+    it('survives dispose — re-subscribe after both updatePulse and dispose works at the new rate', () => {
+      const s = createPulseRefSignal(100);
+      const listener = jest.fn();
+      s.subscribe(listener);
+      s.updatePulse(500);
+      s.dispose();
+
+      // After dispose, subscribers were cleared but updatePulse-stored rate persists.
+      // Re-subscribe spins a fresh session at 500ms.
+      s.subscribe(listener);
+      jest.advanceTimersByTime(100);
+      expect(listener).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(400);
+      expect(listener).toHaveBeenCalledTimes(1);
+      s.dispose();
+    });
+  });
+
+  describe('RAF driver (fps notation)', () => {
+    let raf: ReturnType<typeof setupRafMock>;
+    beforeEach(() => {
+      raf = setupRafMock();
+    });
+    afterEach(() => {
+      raf.restore();
+    });
+
+    it('routes fps notation through requestAnimationFrame', () => {
+      const rafSpy = jest.spyOn(globalThis, 'requestAnimationFrame');
+      const s = createPulseRefSignal('60fps');
+      s.subscribe(jest.fn());
+      expect(rafSpy).toHaveBeenCalled();
+      s.dispose();
+      rafSpy.mockRestore();
+    });
+
+    it('fires only once the interval has elapsed', () => {
+      let nowVal = 0;
+      const perfSpy = jest
+        .spyOn(performance, 'now')
+        .mockImplementation(() => nowVal);
+
+      const s = createPulseRefSignal('60fps'); // ~16.67ms threshold
+      const listener = jest.fn();
+      nowVal = 100;
+      s.subscribe(listener);
+
+      // Frame at +10ms — under threshold (16.17), skip
+      nowVal = 110;
+      raf.fire();
+      expect(listener).not.toHaveBeenCalled();
+      expect(s.tick).toBe(0);
+
+      // Frame at +17ms from last fire — over threshold, fire
+      nowVal = 117;
+      raf.fire();
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(s.tick).toBe(1);
+
+      // Frame at +17ms from previous fire — fire again
+      nowVal = 134;
+      raf.fire();
+      expect(listener).toHaveBeenCalledTimes(2);
+      expect(s.tick).toBe(2);
+      expect(s.dt).toBe(17);
+      expect(s.elapsed).toBe(17);
+
+      s.dispose();
+      perfSpy.mockRestore();
+    });
+
+    it('cancels the RAF loop when last subscriber leaves', () => {
+      const cafSpy = jest.spyOn(globalThis, 'cancelAnimationFrame');
+      const s = createPulseRefSignal('60fps');
+      const a = jest.fn();
+      s.subscribe(a);
+      expect(cafSpy).not.toHaveBeenCalled();
+      s.unsubscribe(a);
+      expect(cafSpy).toHaveBeenCalledTimes(1);
+      s.dispose();
+      cafSpy.mockRestore();
+    });
+
+    it('dispose cancels the RAF loop', () => {
+      const cafSpy = jest.spyOn(globalThis, 'cancelAnimationFrame');
+      const s = createPulseRefSignal('60fps');
+      s.subscribe(jest.fn());
+      s.dispose();
+      expect(cafSpy).toHaveBeenCalledTimes(1);
+      cafSpy.mockRestore();
+    });
+  });
+
+  describe('RAF driver fallback when requestAnimationFrame is missing', () => {
+    it('returns a no-op stop and does not throw', () => {
+      const g = globalThis as unknown as {
+        requestAnimationFrame?: typeof requestAnimationFrame;
+        cancelAnimationFrame?: typeof cancelAnimationFrame;
+      };
+      const savedRaf = g.requestAnimationFrame;
+      const savedCaf = g.cancelAnimationFrame;
+      delete g.requestAnimationFrame;
+      delete g.cancelAnimationFrame;
+      try {
+        const s = createPulseRefSignal('60fps');
+        const listener = jest.fn();
+        expect(() => {
+          s.subscribe(listener);
+        }).not.toThrow();
+        // Without RAF the loop never schedules, so the listener stays silent.
+        expect(listener).not.toHaveBeenCalled();
+        expect(() => {
+          s.unsubscribe(listener);
+        }).not.toThrow();
+        expect(() => {
+          s.dispose();
+        }).not.toThrow();
+      } finally {
+        g.requestAnimationFrame = savedRaf;
+        g.cancelAnimationFrame = savedCaf;
+      }
+    });
+  });
+});

--- a/src/pulse.ts
+++ b/src/pulse.ts
@@ -1,0 +1,280 @@
+import {
+  createRefSignal,
+  Listener,
+  listenersMap,
+  ReadonlyRefSignal,
+} from './refsignal';
+
+/**
+ * The cadence at which a {@link PulseRefSignal} fires.
+ *
+ * - `number` — fixed interval in milliseconds (uses `setInterval`).
+ * - `'Nms'`  — same as the number form, with explicit unit.
+ * - `'Nfps'` — frame-aligned cadence at most N times per second (uses
+ *   `requestAnimationFrame`, so the loop pauses on hidden tabs and
+ *   never runs faster than the display refresh rate).
+ */
+export type PulseRate = number | `${number}ms` | `${number}fps`;
+
+/**
+ * A read-only signal that fires on a schedule. Conceptually a clock primitive.
+ *
+ * Each tick:
+ * - `current` is set to `performance.now()`.
+ * - `notifyUpdate` is called, so subscribers re-run and `lastUpdated` advances.
+ *
+ * Beyond `ReadonlyRefSignal<number>`, exposes per-session metrics:
+ * - `dt` — milliseconds since the previous tick (the time between `current`
+ *   updates). Reset to `0` whenever the timer is (re)started.
+ * - `tick` — number of ticks fired in the current session, starting at `0`
+ *   before the first fire and incrementing by `1` each tick. Reset on
+ *   timer start.
+ * - `elapsed` — milliseconds since the first tick of the current session.
+ *   `0` until the second tick fires.
+ *
+ * Lazy lifecycle: the timer only runs while the signal has at least one
+ * subscriber. It (re)starts on `0 → 1` subscriber transitions and stops on
+ * `1 → 0` and on `dispose`. State (`dt`, `tick`, `elapsed`) is reset each
+ * time the timer (re)starts, so a brief unsubscribe-then-resubscribe yields
+ * a fresh session rather than a spike in `dt`.
+ */
+export interface PulseRefSignal extends ReadonlyRefSignal<number> {
+  readonly dt: number;
+  readonly tick: number;
+  readonly elapsed: number;
+  /**
+   * Change the cadence of an already-created pulse signal. Useful when the
+   * rate is itself reactive — a heartbeat that scales with stamina, polling
+   * that backs off on errors, frame rate that adapts to a perf budget.
+   *
+   * - Validates the new rate (same parser as the constructor; throws on invalid).
+   * - **Continuity preserved**: `tick` and `elapsed` keep going across the
+   *   change. Only `lastTickTime` is reset, so the very next `dt` is
+   *   measured from the rate-change moment, not from the previous tick at
+   *   the old cadence.
+   * - If the timer is currently running, it is stopped and restarted at the
+   *   new cadence. If no subscribers are attached, the new rate is just
+   *   stored and applied on the next `0 → 1` subscriber transition (which
+   *   does its own full session reset, as before).
+   * - Driver may switch (e.g. `'1000ms'` → `'60fps'` swaps `setInterval`
+   *   for `requestAnimationFrame`).
+   *
+   * @example
+   * useRefSignalEffect(() => {
+   *   heartbeat.updatePulse(`${msPerBeat(stamina.current)}ms` as PulseRate);
+   * }, [stamina]);
+   */
+  readonly updatePulse: (rate: PulseRate) => void;
+}
+
+interface ParsedRate {
+  driver: 'raf' | 'interval';
+  intervalMs: number;
+}
+
+const FPS_RE = /^(\d+(?:\.\d+)?)fps$/;
+const MS_RE = /^(\d+(?:\.\d+)?)ms$/;
+
+function parsePulseRate(rate: PulseRate): ParsedRate {
+  if (typeof rate === 'number') {
+    if (!Number.isFinite(rate) || rate <= 0) {
+      throw new Error(
+        `[refsignal] Invalid pulse rate: ${String(rate)}. Must be a positive finite number.`,
+      );
+    }
+    return { driver: 'interval', intervalMs: rate };
+  }
+
+  const fpsMatch = FPS_RE.exec(rate);
+  if (fpsMatch?.[1]) {
+    const fps = parseFloat(fpsMatch[1]);
+    if (!Number.isFinite(fps) || fps <= 0) {
+      throw new Error(
+        `[refsignal] Invalid pulse rate: ${rate}. fps must be positive.`,
+      );
+    }
+    return { driver: 'raf', intervalMs: 1000 / fps };
+  }
+
+  const msMatch = MS_RE.exec(rate);
+  if (msMatch?.[1]) {
+    const ms = parseFloat(msMatch[1]);
+    if (!Number.isFinite(ms) || ms <= 0) {
+      throw new Error(
+        `[refsignal] Invalid pulse rate: ${rate}. ms must be positive.`,
+      );
+    }
+    return { driver: 'interval', intervalMs: ms };
+  }
+
+  throw new Error(
+    `[refsignal] Invalid pulse rate: ${rate}. Expected number | 'Nms' | 'Nfps'.`,
+  );
+}
+
+function startRAFTimer(intervalMs: number, tick: () => void): () => void {
+  if (typeof requestAnimationFrame === 'undefined') return () => {};
+
+  let rafId: number | null = null;
+  let lastFireTime = performance.now();
+  // Half-millisecond slop covers natural frame jitter — without it, a 60fps
+  // request on a 60Hz display can occasionally miss a frame because RAF
+  // delivers slightly under 16.67ms.
+  const threshold = intervalMs - 0.5;
+
+  const loop = () => {
+    const now = performance.now();
+    if (now - lastFireTime >= threshold) {
+      lastFireTime = now;
+      tick();
+    }
+    rafId = requestAnimationFrame(loop);
+  };
+
+  rafId = requestAnimationFrame(loop);
+
+  return () => {
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+  };
+}
+
+function startIntervalTimer(intervalMs: number, tick: () => void): () => void {
+  const id = setInterval(tick, intervalMs);
+  return () => {
+    clearInterval(id);
+  };
+}
+
+/**
+ * Creates a {@link PulseRefSignal} — a self-firing read-only signal whose
+ * `current` advances to `performance.now()` on every tick.
+ *
+ * The timer is lazy: it starts when the signal gets its first subscriber and
+ * stops when subscribers drop back to zero (or on `.dispose()`). Multiple
+ * subscribers share a single underlying timer.
+ *
+ * @param rate Cadence — number of ms, `'Nms'`, or `'Nfps'`. fps notation
+ *   uses `requestAnimationFrame` (frame-aligned, paused on hidden tabs);
+ *   ms notation uses `setInterval`.
+ *
+ * @example
+ * const now = createPulseRefSignal('1000ms');  // every second
+ * const loop = createPulseRefSignal('60fps');  // frame-locked
+ * const tick = createPulseRefSignal(250);      // every 250 ms
+ *
+ * @example
+ * // Auth-token refresh — replaces a setInterval-in-useEffect dance with a
+ * // declarative subscription.
+ * const refreshTick = createPulseRefSignal(4 * 60 * 1000); // every 4 minutes
+ * refreshTick.subscribe(() => { void refreshAuthToken(); });
+ *
+ * @example
+ * // Live "X ago" — one timer, many components, perfect sync via context.
+ * const now = createPulseRefSignal('1000ms');
+ * // …provide via a RefSignalContext, consume from any number of components.
+ */
+export function createPulseRefSignal(
+  rate: PulseRate,
+): PulseRefSignal & { readonly dispose: () => void } {
+  let parsed = parsePulseRate(rate);
+
+  const signal = createRefSignal(performance.now());
+
+  let dt = 0;
+  let tickCount = 0;
+  let elapsed = 0;
+  let firstTickTime = 0;
+  let lastTickTime = 0;
+  let stopTimer: (() => void) | null = null;
+
+  const onTick = () => {
+    const now = performance.now();
+    if (tickCount === 0) {
+      firstTickTime = now;
+      elapsed = 0;
+    } else {
+      elapsed = now - firstTickTime;
+    }
+    dt = now - lastTickTime;
+    lastTickTime = now;
+    tickCount++;
+    signal.current = now;
+    signal.notifyUpdate();
+  };
+
+  const installTimer = () => {
+    if (typeof window === 'undefined') return;
+    stopTimer =
+      parsed.driver === 'raf'
+        ? startRAFTimer(parsed.intervalMs, onTick)
+        : startIntervalTimer(parsed.intervalMs, onTick);
+  };
+
+  const start = () => {
+    // Reset session state so a re-subscribe starts a fresh epoch instead of
+    // observing a giant dt spike across the idle gap.
+    dt = 0;
+    tickCount = 0;
+    elapsed = 0;
+    firstTickTime = 0;
+    lastTickTime = performance.now();
+    installTimer();
+  };
+
+  const stop = () => {
+    if (stopTimer) {
+      stopTimer();
+      stopTimer = null;
+    }
+  };
+
+  const updatePulse = (newRate: PulseRate): void => {
+    // Validate first — throwing parse errors must not leave the timer half-stopped.
+    parsed = parsePulseRate(newRate);
+
+    if (!stopTimer) return; // not running — new rate applies on next start()
+
+    // Continuity: keep tick / elapsed accumulating, only baseline lastTickTime
+    // so the next dt reflects the rate change rather than spanning the
+    // restart.
+    stop();
+    lastTickTime = performance.now();
+    installTimer();
+  };
+
+  const subscriberCount = (): number => listenersMap.get(signal)?.size ?? 0;
+
+  const baseSubscribe = signal.subscribe;
+  const baseUnsubscribe = signal.unsubscribe;
+  const baseDispose = signal.dispose;
+
+  Object.assign(signal, {
+    subscribe: (listener: Listener<number>) => {
+      const before = subscriberCount();
+      baseSubscribe(listener);
+      if (before === 0 && subscriberCount() === 1) start();
+    },
+    unsubscribe: (listener: Listener<number>) => {
+      baseUnsubscribe(listener);
+      if (subscriberCount() === 0) stop();
+    },
+    dispose: () => {
+      stop();
+      baseDispose();
+    },
+    updatePulse,
+  });
+
+  Object.defineProperties(signal, {
+    dt: { get: () => dt, enumerable: true },
+    tick: { get: () => tickCount, enumerable: true },
+    elapsed: { get: () => elapsed, enumerable: true },
+  });
+
+  return signal as unknown as PulseRefSignal & {
+    readonly dispose: () => void;
+  };
+}


### PR DESCRIPTION
## Summary

Adds `PulseRefSignal` — a self-firing read-only signal whose `.current` advances to `performance.now()` on a schedule, with `dt`/`tick`/`elapsed` as tick-context metadata. Two factories: `createPulseRefSignal(rate)` and `usePulseRefSignal(rate)`. Cadence is reactive via `updatePulse(rate)` — heartbeat that scales with stamina, polling backoff, adaptive frame rate.

- Rate format: `number | 'Nms' | 'Nfps'`. `fps` → RAF (frame-aligned, paused on hidden tabs); ms → setInterval.
- Lazy lifecycle: timer runs only while ≥1 subscriber. Multiple subscribers share one timer — provider pattern gives N components one synchronized tick stream.
- `updatePulse` preserves `tick`/`elapsed` continuity across rate changes; only `lastTickTime` is reset so the next `dt` reflects the change.
- No `persist` / `broadcast` options exposed — `performance.now()` is bound to the document's `timeOrigin` and meaningless to serialize / send across tabs. Documented at signal-level *and* the store-level trap (the latter doesn't have type-system protection).
- SSR-safe: constructs cleanly in non-browser env, timer doesn't install until `window` is available.
- 100% coverage on `pulse.ts` and `usePulseRefSignal.ts` (50 new tests).

Docs: dedicated `pulse.md`, entries in `api.md`, new section in `decision-tree.md`, "Shared pulse via provider" pattern in `patterns.md`, "Pulse signals — clocks with tick-context metadata" in `concepts.md`, breadcrumbs updated across all docs, README docs index updated.

## Test plan

- [ ] `npm test` — 515 tests pass (was 508, +7 new for `updatePulse` semantics on top of the 43 added with the initial pulse implementation)
- [ ] `npm run typecheck` — clean
- [ ] `npm run lint` — clean
- [ ] `npm run coverage` — 100% on new files
- [ ] Verify `pulse.md` reads cleanly on GitHub (mermaid in `decision-tree.md` § 11 too)
- [ ] Sanity-check `useBackoffPulse` recipe — composes from `usePulseRefSignal` + `updatePulse` only, ~10 lines, no core API additions