### PR TITLE
fix: devtools leak on signal dispose

### DIFF
--- a/src/devtools.test.ts
+++ b/src/devtools.test.ts
@@ -300,6 +300,34 @@ describe('DevTools', () => {
     expect(devtools.getUpdateHistory()).toHaveLength(100);
   });
 
+  it('clears named signal from devtools on dispose', () => {
+    const signal = createRefSignal(0, 'disposed');
+    expect(devtools.getSignalByName('disposed')).toBe(signal);
+
+    signal.dispose();
+
+    expect(devtools.getSignalByName('disposed')).toBeUndefined();
+    expect(devtools.getSignalName(signal)).toBeUndefined();
+  });
+
+  it('clears unnamed signal tracking on dispose', () => {
+    const signal = createRefSignal(0);
+    expect(devtools.getSignalName(signal)).toMatch(/^signal_\d+$/);
+
+    signal.dispose();
+
+    expect(devtools.getSignalName(signal)).toBeUndefined();
+  });
+
+  it('dispose is idempotent for devtools cleanup', () => {
+    const signal = createRefSignal(0, 'twice');
+    signal.dispose();
+    expect(() => {
+      signal.dispose();
+    }).not.toThrow();
+    expect(devtools.getSignalByName('twice')).toBeUndefined();
+  });
+
   it('should handle multiple signals independently', () => {
     const counter = createRefSignal(0, 'counter');
     const message = createRefSignal('', 'message');

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -84,7 +84,7 @@ class DevTools implements DevToolsAdapter {
     }
   }
 
-  registerSignal<T>(signal: RefSignal<T>, name?: string): string {
+  registerSignal<T>(signal: RefSignal<T>, name?: string): () => void {
     const id = name ?? `signal_${String(this.signalIdCounter++)}`;
     this.signals.set(signal as object, id);
 
@@ -92,7 +92,10 @@ class DevTools implements DevToolsAdapter {
       this.signalsByName.set(name, signal as RefSignal);
     }
 
-    return id;
+    return () => {
+      if (name) this.signalsByName.delete(name);
+      this.signals.delete(signal as object);
+    };
   }
 
   trackUpdate<T>(signal: RefSignal<T>, oldValue: T, newValue: T): void {

--- a/src/refsignal.ts
+++ b/src/refsignal.ts
@@ -5,7 +5,10 @@ export type Listener<T = unknown> = (value: T) => void;
 
 export interface DevToolsAdapter {
   trackUpdate<T>(signal: RefSignal<T>, oldValue: T, newValue: T): void;
-  registerSignal<T>(signal: RefSignal<T>, debugName?: string): void;
+  registerSignal<T>(
+    signal: RefSignal<T>,
+    debugName?: string,
+  ): (() => void) | undefined;
   getSignalName<T>(signal: RefSignal<T>): string | undefined;
 }
 
@@ -275,7 +278,8 @@ export function createRefSignal<T = unknown>(
     },
   };
 
-  devtoolsAdapter?.registerSignal(signal, debugName);
+  const devtoolsCleanup = devtoolsAdapter?.registerSignal(signal, debugName);
+  if (devtoolsCleanup) cleanups.push(devtoolsCleanup);
 
   if (resolved?.broadcast) {
     const cleanup = attachSignalBroadcast(signal, resolved.broadcast);


### PR DESCRIPTION
## Summary
- `devtools.signalsByName` (`Map<string, RefSignal>`) held strong refs to every named signal — `dispose()` cleared subscribers but never told devtools, leaking signals in long-running apps and forcing `devtools.reset()` between tests.
- `DevToolsAdapter.registerSignal` may now return a cleanup; `createRefSignal` pushes it onto the same `cleanups` list used by broadcast/persist, so `dispose()` unwinds devtools tracking via the existing pattern (no new direct call into devtools).
- After dispose: `getSignalByName(name)` and `getSignalName(signal)` both return `undefined`.

## Test plan
- [x] `npm test` — 518/518
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] 3 new tests in `devtools.test.ts`: named cleanup, unnamed cleanup, idempotent double-dispose
