### PR TITLE
feat: 'raf' pulse rate

### DIFF
--- a/demo/graph-benchmark.tsx
+++ b/demo/graph-benchmark.tsx
@@ -18,7 +18,11 @@ import React, {
   createContext,
   memo,
 } from 'react';
-import { createRefSignal, useRefSignalEffect } from 'react-refsignal';
+import {
+  createRefSignal,
+  usePulseRefSignal,
+  useRefSignalEffect,
+} from 'react-refsignal';
 import type { RefSignal } from 'react-refsignal';
 import { create } from 'zustand';
 import { atom, useAtom, Provider as JotaiProvider } from 'jotai';
@@ -400,27 +404,32 @@ function RGraph({ count }: { count: number }) {
 function Stats({ mode }: { mode: string }) {
   const fpsRef = useRef<HTMLSpanElement>(null);
   const rpsRef = useRef<HTMLSpanElement>(null);
+  const frame = usePulseRefSignal('raf');
+  const framesRef = useRef(0);
+  const lastSampleRef = useRef(0);
+  const prevRendersRef = useRef(0);
+
   useEffect(() => {
-    let frames = 0;
-    let prevTime = performance.now();
-    let prevRenders = getRenders();
-    let id: number;
-    const tick = () => {
-      frames++;
-      const now = performance.now();
-      if (now - prevTime >= 1000) {
+    framesRef.current = 0;
+    lastSampleRef.current = frame.elapsed;
+    prevRendersRef.current = getRenders();
+  }, [mode, frame]);
+
+  useRefSignalEffect(
+    () => {
+      if (frame.tick === 0) return;
+      framesRef.current++;
+      if (frame.elapsed - lastSampleRef.current >= 1000) {
         const r = getRenders();
-        if (fpsRef.current) fpsRef.current.textContent = String(frames);
-        if (rpsRef.current) rpsRef.current.textContent = String(r - prevRenders);
-        frames = 0;
-        prevRenders = r;
-        prevTime = now;
+        if (fpsRef.current) fpsRef.current.textContent = String(framesRef.current);
+        if (rpsRef.current) rpsRef.current.textContent = String(r - prevRendersRef.current);
+        framesRef.current = 0;
+        prevRendersRef.current = r;
+        lastSampleRef.current = frame.elapsed;
       }
-      id = requestAnimationFrame(tick);
-    };
-    id = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(id);
-  }, [mode]);
+    },
+    [frame],
+  );
   return (
     <>
       <span style={statBadge}>FPS <b ref={fpsRef} style={{ minWidth: 28, display: 'inline-block' }}>--</b></span>

--- a/docs/api.md
+++ b/docs/api.md
@@ -105,16 +105,17 @@ A self-firing read-only signal whose `.current` advances to `performance.now()` 
 The cadence accepted by [`createPulseRefSignal`](#createpulserefsignalrate) and [`usePulseRefSignal`](#usepulserefsignalrate).
 
 ```ts
-type PulseRate = number | `${number}ms` | `${number}fps`;
+type PulseRate = number | `${number}ms` | `${number}fps` | 'raf';
 ```
 
 | Form | Driver | When to reach for it |
 |---|---|---|
 | `number` (e.g. `100`) | `setInterval` | Same as the `'Nms'` form — a bare number is implicitly milliseconds. |
 | `'Nms'` (e.g. `'250ms'`, `'16.67ms'`) | `setInterval` | Continues firing on hidden tabs (subject to browser background-tab throttling). Use for clocks, polling, heartbeats, token refresh. |
-| `'Nfps'` (e.g. `'60fps'`, `'30fps'`) | `requestAnimationFrame` | Frame-aligned, paused on hidden tabs, capped by display refresh rate. Use for game loops, animations. |
+| `'Nfps'` (e.g. `'60fps'`, `'30fps'`) | `requestAnimationFrame` | Throttled to at most N/sec. Use when you specifically want a capped rate (power-saving, retro framelock, sub-display-refresh animation). |
+| `'raf'` | `requestAnimationFrame` | Every frame at the display's native rate (60Hz / 120Hz / 144Hz / …), no throttle. Use for game loops, FPS counters, anything that should run as fast as the screen draws. |
 
-Decimals are accepted in both string forms. A non-positive or non-finite rate throws at construction.
+Decimals are accepted in both numeric string forms. A non-positive or non-finite rate throws at construction.
 
 ---
 
@@ -493,7 +494,8 @@ Creates a [`PulseRefSignal`](#pulserefsignal) outside React — at module scope,
 import { createPulseRefSignal } from 'react-refsignal';
 
 const now      = createPulseRefSignal('1000ms');  // every second
-const loop     = createPulseRefSignal('60fps');   // frame-locked
+const loop     = createPulseRefSignal('60fps');   // throttled to 60
+const frame    = createPulseRefSignal('raf');     // every frame, native rate
 const everyHalf = createPulseRefSignal(500);      // bare number — same as '500ms'
 ```
 

--- a/docs/decision-tree.md
+++ b/docs/decision-tree.md
@@ -296,10 +296,11 @@ flowchart TD
     Q2 -->|"Module scope / context factory / outside React"| B["createPulseRefSignal(rate)\n→ remember to call .dispose() if you own the lifetime"]
 
     A & B --> Q3{"What cadence?"}
-    Q3 -->|"Frame-aligned, paused on hidden tabs (animation, game loops)"| F["'60fps' / '30fps' — RAF driver"]
+    Q3 -->|"Every frame at the display's native rate (game loops, FPS counters, smooth animation)"| R["'raf' — RAF driver, no throttle"]
+    Q3 -->|"Throttled to N fps (power-saving, retro framelock, capped animation)"| F["'60fps' / '30fps' — RAF driver, throttled"]
     Q3 -->|"Time-based, must keep firing on hidden tabs (clocks, polling, heartbeats)"| M["'1000ms' or 1000 — setInterval driver"]
 
-    F & M --> Q4{"Multiple components need the same tick stream?"}
+    R & F & M --> Q4{"Multiple components need the same tick stream?"}
     Q4 -->|"No — single consumer"| Done1[Done]
     Q4 -->|"Yes — share one timer across many components"| P["Provide via context:\nN consumers, one timer, perfect sync.\nSee pulse.md → Shared tick via provider."]
 

--- a/docs/pulse.md
+++ b/docs/pulse.md
@@ -36,7 +36,8 @@ import { createPulseRefSignal, usePulseRefSignal } from 'react-refsignal';
 
 // Outside React — module scope, context factories, anywhere.
 const now      = createPulseRefSignal('1000ms'); // every second
-const loop     = createPulseRefSignal('60fps');  // frame-locked
+const loop     = createPulseRefSignal('60fps');  // throttled to 60
+const frame    = createPulseRefSignal('raf');    // every frame, native rate
 const everyHalf = createPulseRefSignal(500);     // number — same as '500ms'
 
 // Inside React — lifetime tied to the component.
@@ -47,15 +48,16 @@ function Clock() {
 }
 ```
 
-Three accepted rate formats:
+Four accepted rate formats:
 
 | Form | Driver | Note |
 |---|---|---|
 | `number` (e.g. `100`) | `setInterval` | ms — same as the `'Nms'` form |
 | `'Nms'` (e.g. `'250ms'`, `'16.67ms'`) | `setInterval` | ms with explicit unit |
-| `'Nfps'` (e.g. `'60fps'`, `'30fps'`) | `requestAnimationFrame` | frame-aligned, paused on hidden tabs |
+| `'Nfps'` (e.g. `'60fps'`, `'30fps'`) | `requestAnimationFrame` | throttled to at most N/sec, paused on hidden tabs |
+| `'raf'` | `requestAnimationFrame` | every frame at the display's native rate (60Hz / 120Hz / 144Hz / …), no throttle |
 
-Decimals are accepted in both string forms.
+Decimals are accepted in both numeric string forms.
 
 ---
 
@@ -105,7 +107,8 @@ A pulse signal that is never subscribed to never installs a timer. It costs noth
 
 The rate format picks the driver:
 
-- **`'Nfps'` → `requestAnimationFrame`.** Frame-aligned. Pauses on hidden tabs (the browser stops calling RAF). Capped by the display refresh rate — requesting `'120fps'` on a 60Hz display gives you 60. Use this for game loops, animation, anything that should be visible-time-aware.
+- **`'raf'` → `requestAnimationFrame`, every frame.** Follows the display's native refresh rate — 60Hz, 120Hz, 144Hz, whatever the user has. No throttle gate, no target fps to pick, no skipped frames on a faster display. Pauses on hidden tabs. Use this when "as fast as the screen draws" is what you actually want — game loops, frame-based animation, FPS counters.
+- **`'Nfps'` → `requestAnimationFrame`, throttled to N.** Same RAF driver, but skips frames to cap firing at N/sec. Useful for power-saving (`'30fps'` for a passive animation) or for a target rate that should hold even on a 144Hz display. Note that `'60fps'` on a 60Hz display effectively matches `'raf'`; on a 120Hz display it actively throttles you to ~60. If you're not sure which you want, `'raf'` is usually it.
 - **`number` / `'Nms'` → `setInterval`.** Continues firing on hidden tabs (subject to browser's background-tab throttling). Drift may accumulate over long sessions. Use this for clocks, polling, heartbeats, token refresh — anything where missing a tick on a hidden tab would be a bug, not a feature.
 
 You'd reach for `'Nms'` over a number when you want the unit to show up in code review (`'250ms'` reads as a duration; `250` could be anything).
@@ -178,7 +181,7 @@ That's it. No `useEffect`, no stale-closure ref dance, no cleanup forgotten on a
 
 ```tsx
 function Particles() {
-  const loop = usePulseRefSignal('60fps');
+  const loop = usePulseRefSignal('raf');
 
   useRefSignalEffect(() => {
     advancePhysics(loop.dt);   // ms since previous tick

--- a/src/pulse.test.ts
+++ b/src/pulse.test.ts
@@ -25,6 +25,12 @@ describe('createPulseRefSignal', () => {
       s.dispose();
     });
 
+    it("accepts 'raf'", () => {
+      const s = createPulseRefSignal('raf');
+      expect(typeof s.current).toBe('number');
+      s.dispose();
+    });
+
     it('accepts decimal ms and fps', () => {
       const a = createPulseRefSignal('16.67ms');
       const b = createPulseRefSignal('59.94fps');
@@ -62,6 +68,10 @@ describe('createPulseRefSignal', () => {
       expect(() => createPulseRefSignal('hello' as never)).toThrow(
         /Invalid pulse rate/,
       );
+    });
+
+    it("error message lists 'raf' as an accepted form", () => {
+      expect(() => createPulseRefSignal('hello' as never)).toThrow(/'raf'/);
     });
 
     it("rejects '0fps' and '0ms'", () => {
@@ -543,6 +553,99 @@ describe('createPulseRefSignal', () => {
     it('dispose cancels the RAF loop', () => {
       const cafSpy = jest.spyOn(globalThis, 'cancelAnimationFrame');
       const s = createPulseRefSignal('60fps');
+      s.subscribe(jest.fn());
+      s.dispose();
+      expect(cafSpy).toHaveBeenCalledTimes(1);
+      cafSpy.mockRestore();
+    });
+  });
+
+  describe("'raf' driver — native-rate, no throttle", () => {
+    let raf: ReturnType<typeof setupRafMock>;
+    beforeEach(() => {
+      raf = setupRafMock();
+    });
+    afterEach(() => {
+      raf.restore();
+    });
+
+    it('routes through requestAnimationFrame', () => {
+      const rafSpy = jest.spyOn(globalThis, 'requestAnimationFrame');
+      const s = createPulseRefSignal('raf');
+      s.subscribe(jest.fn());
+      expect(rafSpy).toHaveBeenCalled();
+      s.dispose();
+      rafSpy.mockRestore();
+    });
+
+    it('fires on every frame regardless of inter-frame interval', () => {
+      let nowVal = 0;
+      const perfSpy = jest
+        .spyOn(performance, 'now')
+        .mockImplementation(() => nowVal);
+
+      const s = createPulseRefSignal('raf');
+      const listener = jest.fn();
+      nowVal = 100;
+      s.subscribe(listener);
+
+      // Frame at +1ms — under any reasonable fps throttle, but 'raf' has none
+      nowVal = 101;
+      raf.fire();
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(s.tick).toBe(1);
+
+      // Frame at +1ms again — still fires
+      nowVal = 102;
+      raf.fire();
+      expect(listener).toHaveBeenCalledTimes(2);
+      expect(s.tick).toBe(2);
+
+      // Frame at +8ms — would be skipped at '60fps' (~16.67 threshold), still fires
+      nowVal = 110;
+      raf.fire();
+      expect(listener).toHaveBeenCalledTimes(3);
+      expect(s.tick).toBe(3);
+      expect(s.dt).toBe(8);
+      expect(s.elapsed).toBe(9);
+
+      s.dispose();
+      perfSpy.mockRestore();
+    });
+
+    it("updatePulse('60fps' → 'raf') drops the throttle", () => {
+      let nowVal = 0;
+      const perfSpy = jest
+        .spyOn(performance, 'now')
+        .mockImplementation(() => nowVal);
+
+      const s = createPulseRefSignal('60fps');
+      const listener = jest.fn();
+      nowVal = 0;
+      s.subscribe(listener);
+
+      // 60fps: a 5ms frame is below threshold and skipped
+      nowVal = 5;
+      raf.fire();
+      expect(listener).not.toHaveBeenCalled();
+
+      // Switch to 'raf' — the throttle gate disappears
+      s.updatePulse('raf');
+
+      nowVal = 6;
+      raf.fire();
+      expect(listener).toHaveBeenCalledTimes(1);
+      nowVal = 7;
+      raf.fire();
+      expect(listener).toHaveBeenCalledTimes(2);
+
+      s.dispose();
+      perfSpy.mockRestore();
+    });
+
+    it('cancels the RAF loop on dispose', () => {
+      const cafSpy = jest.spyOn(globalThis, 'cancelAnimationFrame');
+      const s = createPulseRefSignal('raf');
       s.subscribe(jest.fn());
       s.dispose();
       expect(cafSpy).toHaveBeenCalledTimes(1);

--- a/src/pulse.ts
+++ b/src/pulse.ts
@@ -10,11 +10,14 @@ import {
  *
  * - `number` — fixed interval in milliseconds (uses `setInterval`).
  * - `'Nms'`  — same as the number form, with explicit unit.
- * - `'Nfps'` — frame-aligned cadence at most N times per second (uses
- *   `requestAnimationFrame`, so the loop pauses on hidden tabs and
- *   never runs faster than the display refresh rate).
+ * - `'Nfps'` — frame-aligned cadence throttled to at most N times per
+ *   second (uses `requestAnimationFrame`, so the loop pauses on hidden
+ *   tabs).
+ * - `'raf'`  — every animation frame, with no throttle. Follows the
+ *   display's refresh rate (60Hz, 120Hz, 144Hz, …). Use this when you
+ *   want "as fast as the screen draws" rather than a target fps.
  */
-export type PulseRate = number | `${number}ms` | `${number}fps`;
+export type PulseRate = number | `${number}ms` | `${number}fps` | 'raf';
 
 /**
  * A read-only signal that fires on a schedule. Conceptually a clock primitive.
@@ -85,6 +88,13 @@ function parsePulseRate(rate: PulseRate): ParsedRate {
     return { driver: 'interval', intervalMs: rate };
   }
 
+  // 'raf' — every frame, no throttle. intervalMs: 0 makes the driver's
+  // threshold gate a no-op (see startRAFTimer), so it fires on every
+  // requestAnimationFrame callback at the display's native rate.
+  if (rate === 'raf') {
+    return { driver: 'raf', intervalMs: 0 };
+  }
+
   const fpsMatch = FPS_RE.exec(rate);
   if (fpsMatch?.[1]) {
     const fps = parseFloat(fpsMatch[1]);
@@ -108,7 +118,7 @@ function parsePulseRate(rate: PulseRate): ParsedRate {
   }
 
   throw new Error(
-    `[refsignal] Invalid pulse rate: ${rate}. Expected number | 'Nms' | 'Nfps'.`,
+    `[refsignal] Invalid pulse rate: ${rate}. Expected number | 'Nms' | 'Nfps' | 'raf'.`,
   );
 }
 
@@ -156,13 +166,15 @@ function startIntervalTimer(intervalMs: number, tick: () => void): () => void {
  * stops when subscribers drop back to zero (or on `.dispose()`). Multiple
  * subscribers share a single underlying timer.
  *
- * @param rate Cadence — number of ms, `'Nms'`, or `'Nfps'`. fps notation
- *   uses `requestAnimationFrame` (frame-aligned, paused on hidden tabs);
- *   ms notation uses `setInterval`.
+ * @param rate Cadence — number of ms, `'Nms'`, `'Nfps'`, or `'raf'`. fps
+ *   notation throttles `requestAnimationFrame` to at most N times per
+ *   second; `'raf'` fires on every frame at the display's native rate
+ *   (60Hz / 120Hz / 144Hz / …); ms notation uses `setInterval`.
  *
  * @example
  * const now = createPulseRefSignal('1000ms');  // every second
- * const loop = createPulseRefSignal('60fps');  // frame-locked
+ * const loop = createPulseRefSignal('60fps');  // throttled to 60
+ * const frame = createPulseRefSignal('raf');   // every frame, native rate
  * const tick = createPulseRefSignal(250);      // every 250 ms
  *
  * @example


### PR DESCRIPTION
## Summary

Adds `'raf'` as a fourth `PulseRate` form: every `requestAnimationFrame` callback at the display's native rate (60 / 120 / 144 Hz / …), no throttle. Closes the gap where `'60fps'` actively throttled to ~60 even on a 144 Hz display, and there was no way to say "follow the screen."

The `'Nfps'` form keeps its existing meaning (intentional throttle for power-saving / capped animation). The new form means "let the display decide."

## Implementation

- `parsePulseRate('raf')` returns `{ driver: 'raf', intervalMs: 0 }`. The existing RAF driver subtracts 0.5 from `intervalMs` to compute its threshold, so 0 → -0.5 → fires on every frame. No driver code change needed.
- Type widens to `number | \`${number}ms\` | \`${number}fps\` | 'raf'`.
- Error message lists `'raf'` alongside the other forms.

## Docs

- `docs/pulse.md` — quick-start example, rate table (now 4 forms), drivers section explains when to reach for `'raf'` vs `'Nfps'`.
- `docs/api.md` — `PulseRate` type table updated.
- `docs/decision-tree.md` — Section 11 splits the RAF branch into "every frame" vs "throttled to N".
- Game-loop recipe in `pulse.md` migrated from `'60fps'` to `'raf'` (the right call for variable-step physics on high-refresh displays).

## Demo

`demo/graph-benchmark.tsx` `Stats` overlay swapped from a hand-rolled `useEffect` + `requestAnimationFrame` loop to `usePulseRefSignal('raf')` + `useRefSignalEffect`. Reads `frame.elapsed` for 1-second sampling — same FPS / renders-per-second behavior, declarative.

## Test plan

- [x] `npm test` — 524 passing (3 new: parser accepts `'raf'`, fires every frame regardless of inter-frame interval, `updatePulse('60fps' → 'raf')` drops the throttle)
- [x] `npm run lint`
- [x] `npm run build` (typecheck + tsup)
- [ ] Manual: open the demo on a 120 Hz display, verify FPS reads ~120 (was capped at ~60 before)