### PR TITLE
docs: readme + demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,23 +8,31 @@
 [![bundlephobia](https://badgen.net/bundlephobia/minzip/react-refsignal)](https://bundlephobia.com/result?p=react-refsignal)
 [![MIT License](https://img.shields.io/github/license/jav974/react-refsignal.svg)](LICENSE)
 
-Mutable signal-like refs for React — update values without re-rendering, subscribe to changes, and opt into re-renders exactly where you need them.
+Mutable signal-like refs for React where every consumer dictates its own subscription contract — *what* to observe, *when* to react, *whether* to trigger a re-render — independently, per call site.
+
+The same signal can drive a 60 FPS canvas in one place, a throttled HUD label elsewhere, and a normal React component watching a derived boolean — at the same time, with no coordination between them.
+
+Built for UIs where React's render cycle is the bottleneck: **node editors (n8n-class), real-time simulations, drag-heavy canvases**. Scales down cleanly to ordinary state.
 
 > **[Live demo →](https://stackblitz.com/edit/vitejs-vite-jurlgxkf?file=index.html)** — drag the nodes; sixty FPS, zero React re-renders.
 
 ## Why
 
-Imagine a canvas with a hundred draggable nodes, each connected by curves. The user drags one node — its position changes sixty times a second. Every curve attached to it must follow. The other ninety-nine nodes should be completely unaffected.
+Most React state libraries are *producer-driven*: the store decides when consumers are notified, and selectors, equality functions, or observer wrappers narrow it from there. The producer dictates the contract.
 
-React's render cycle is the wrong layer for this. You don't want a re-render — you want a targeted notification: *this value changed, only the things watching it should react*.
+refsignal inverts that. The signal is just a value with a channel. **Each consumer, at its call site, decides three things independently:**
 
-`useRef` gets you out of the render cycle, but a ref is silent. Nothing can subscribe to it. You end up building a manual event emitter per node — registration, cleanup, ordering. That's the library you'd be writing from scratch.
+- **What** to observe — the whole signal, a projection, a derived value
+- **When** to react — synchronous, throttled, debounced, `rAF`, or a custom `filter`
+- **Whether** to render — pure side-effect, or opt into a React re-render
 
-`react-refsignal` is that primitive: **a ref with a subscription channel**. When a position signal updates, only its subscribers run — directly, synchronously, with no React scheduler involved. One effect redraws the curve. Another updates a HUD label. Everything else is untouched.
+Take a draggable node in a canvas editor. Its position updates sixty times a second. One consumer redraws the connecting curve every frame (`rAF`-paced, no render). Another updates a HUD label, throttled to 100 ms (no render). A third logs to analytics every second. A fourth is a React component watching a derived `isOnscreen` boolean — re-renders only when that flips. **Same signal, four contracts, no coordination.**
 
-Outside of high-frequency scenarios, the same model scales down cleanly. Components opt into re-renders explicitly — no selector callbacks, no wrapper components, no observability magic. Just `useRefSignalRender([signal])` where you need it and nothing elsewhere.
+Producers can be time-driven too: a pulse signal ticks on a schedule (`'1000ms'`, `'60fps'`, `'raf'`) and slots into the same model — one shared timer per cadence, lazily started, with each consumer rate-limiting on top.
 
-The API stays within React's public contract: `useSyncExternalStore` for render subscriptions, direct listener callbacks for effects. No compiler, no proxy, no patched internals.
+That model is why refsignal holds 60 FPS where a conventional store crawls below 1 FPS in a dense node-editor benchmark: high-frequency consumers don't pay for the render policy of low-frequency ones. Reconciliation isn't on the path unless a consumer explicitly opts in. Outside high-frequency scenarios the same model scales down — components opt into re-renders explicitly via `useRefSignalRender([signal])`, and nothing renders elsewhere.
+
+`useRef` gets you out of the render cycle, but a ref is silent — nothing can subscribe. Build the subscription channel yourself and you're writing this library from scratch. refsignal is that primitive: **a ref with a per-consumer subscription channel**, built on stable, public React APIs (`useSyncExternalStore` for renders, direct listeners for effects). No compiler, no proxy, no patched internals.
 
 ## Installation
 
@@ -36,7 +44,28 @@ Requires React ≥ 18.0.0.
 
 ## Quick Start
 
-The simplest use: a signal that drives a re-render.
+The model shines when you want updates _without_ re-renders — like driving a canvas from a game loop. A pulse signal ticks every frame; the canvas redraws on each tick; React's render cycle is never involved.
+
+```tsx
+import { useRef } from 'react';
+import { usePulseRefSignal, useRefSignalEffect } from 'react-refsignal';
+
+function GameCanvas() {
+  const loop = usePulseRefSignal('raf');
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useRefSignalEffect(() => {
+    const ctx = canvasRef.current?.getContext('2d');
+    if (!ctx) return;
+    ctx.clearRect(0, 0, 800, 600);
+    ctx.fillRect(loop.tick, 0, 20, 20);
+  }, [loop]);
+
+  return <canvas ref={canvasRef} width={800} height={600} />;
+}
+```
+
+The same model scales down to ordinary state — opt into a re-render exactly where you want one:
 
 ```tsx
 import { useRefSignal, useRefSignalRender } from 'react-refsignal';
@@ -57,52 +86,82 @@ function Counter() {
 
 Without `useRefSignalRender`, `count.update()` updates the value and notifies subscribers — but the component never re-renders. That is the point: renders are opt-in.
 
-The real power shows when you want updates _without_ re-renders — for example, driving a canvas from a game loop:
+The producer can also be a clock — pulse signals tick on a schedule and slot into the same graph:
 
 ```tsx
-import { useEffect, useRef } from 'react';
-import { useRefSignal, useRefSignalEffect } from 'react-refsignal';
+import { createPulseRefSignal, useRefSignalRender } from 'react-refsignal';
 
-function GameCanvas() {
-  const position = useRefSignal({ x: 0, y: 0 });
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+// Module scope: one timer for the whole app, lazily started by the first reader.
+const now = createPulseRefSignal('60000ms'); // every minute
 
-  useEffect(() => {
-    let id: number;
-    const tick = () => {
-      position.current.x += 1;
-      position.notify(); // fire subscribers — no React re-render
-      id = requestAnimationFrame(tick);
-    };
-    id = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(id);
-  }, []);
-
-  useRefSignalEffect(() => {
-    const ctx = canvasRef.current?.getContext('2d');
-    if (!ctx) return;
-    ctx.clearRect(0, 0, 800, 600);
-    ctx.fillRect(position.current.x, position.current.y, 20, 20);
-  }, [position]);
-
-  return <canvas ref={canvasRef} width={800} height={600} />;
+function RelativeTime({ at }: { at: number }) {
+  useRefSignalRender([now]);
+  return <time>{formatAgo(at, now.current)}</time>;
 }
 ```
 
-The canvas redraws at every frame via `useRefSignalEffect` — React's render cycle is never involved.
+Mount fifty `<RelativeTime />` cells; you get fifty subscribers on one `setInterval`. Unmount them all and the timer stops. The timer never installs at all if no consumer subscribes.
+
+## Per-consumer subscription
+
+Every consumer of a signal picks its own **what / when / whether** at the call site. The signal doesn't know — and doesn't care — what its consumers do.
+
+Same `position` signal, four contracts, no coordination between them:
+
+```tsx
+const position = useRefSignal({ x: 0, y: 0 });
+
+// 1. Redraw a curve every frame — no React render
+useRefSignalEffect(() => {
+  drawCurve(canvasRef.current, position.current);
+}, [position], { rAF: true });
+
+// 2. Update a HUD label, throttled to 100 ms — no React render
+useRefSignalEffect(() => {
+  hudRef.current!.textContent = `${position.current.x}, ${position.current.y}`;
+}, [position], { throttle: 100 });
+
+// 3. Log to analytics, debounced to fire on idle — no React render
+useRefSignalEffect(() => {
+  analytics.track('position', position.current);
+}, [position], { debounce: 1000 });
+
+// 4. A derived boolean — re-render only when it flips
+const isOnscreen = useRefSignalMemo(
+  () => position.current.x >= 0 && position.current.x < viewportWidth,
+  [position],
+);
+useRefSignalRender([isOnscreen]);
+```
+
+Adding or removing any one of these doesn't affect the others. Reconciliation is on the path only for consumer #4 — and only when the boolean actually flips.
+
+Every hook that subscribes (`useRefSignalEffect`, `useRefSignalRender`, `useRefSignalMemo`, and the framework-agnostic `watch()`) accepts the same options: `throttle`, `debounce`, `rAF`, `filter`, `maxWait`. The producer never participates in the timing decision.
 
 ## Docs
 
-- **[Decision Tree](docs/decision-tree.md)** — start here. Picks the right API for any scenario (signal creation, derived values, persistence, broadcast, context, batching). Useful as a navigation index for humans and as a generation reference for AI tools.
-- [Patterns](docs/patterns.md) — full worked examples: draggable graphs, signal stores, collections, batching, high-frequency consumers, filtered renders, the sibling-leaf pattern for data hooks, and the cross-tab notification badge recipe.
-- [API Reference](docs/api.md) — every hook and function with examples.
-- [Concepts](docs/concepts.md) — signals, notify vs notifyUpdate, effect vs render, signal lifetime.
-- [Imperative renderers](docs/imperative-renderers.md) — Canvas / Pixi / WebGL / audio driven by signals, bypassing React reconciliation.
-- [Pulse](docs/pulse.md) — self-firing signals (`createPulseRefSignal` / `usePulseRefSignal`): clocks, game loops, auth refresh, shared tick across components.
-- [Cross-tab Broadcast](docs/broadcast.md) — sync signals across tabs with `react-refsignal/broadcast`.
-- [Persist](docs/persist.md) — persist signals across page loads with `react-refsignal/persist`.
+Organized by intent, not by API surface.
 
-The full `docs/` folder is bundled with the npm package — installed at `node_modules/react-refsignal/docs/`. AI coding tools and IDEs can read it directly without fetching from GitHub.
+**Start here**
+- **[Decision Tree](docs/decision-tree.md)** — pick the right API for any scenario (signal creation, derived values, persistence, broadcast, context, batching). Doubles as a generation reference for AI tools.
+
+**Foundations**
+- [Concepts](docs/concepts.md) — `RefSignal` vs `ReadonlyRefSignal` vs `ComputedSignal`, `notify()` vs `notifyUpdate()`, effect vs render, signal lifetime.
+- [API Reference](docs/api.md) — every hook and function with examples.
+
+**Building with it**
+- [Pulse](docs/pulse.md) — time-driven signals: clocks, frame loops, "X ago" timestamps, adaptive cadences via `updatePulse`.
+- [Patterns](docs/patterns.md) — draggable graphs, signal stores, collections, batching, high-frequency consumers, filtered renders, the sibling-leaf pattern, cross-tab notification badges.
+- [Imperative renderers](docs/imperative-renderers.md) — Canvas / Pixi / WebGL / audio driven by signals, bypassing React reconciliation.
+- [Persist](docs/persist.md) — persist signals across page loads (`localStorage`, `sessionStorage`, IndexedDB, custom adapters).
+- [Cross-tab Broadcast](docs/broadcast.md) — sync signals across tabs.
+- [Benchmark](docs/benchmark.md) — the methodology behind the 60-FPS numbers.
+
+## Built for AI-assisted coding
+
+The `docs/` folder ships inside the npm package — installed at `node_modules/react-refsignal/docs/`. Cursor, Claude Code, and other LLM-backed editors read it directly, no GitHub fetch required.
+
+The [Decision Tree](docs/decision-tree.md) is intentionally written as a generation reference: when an AI assistant asks "which API fits here?", it has a deterministic answer instead of guessing between `useRefSignal`, `useRefSignalEffect`, `useRefSignalRender`, `useRefSignalMemo`, and a store. Fewer wrong-shape suggestions, fewer stray re-renders.
 
 ## Concepts
 
@@ -115,6 +174,8 @@ The full `docs/` folder is bundled with the npm package — installed at `node_m
 | `createComputedRefSignal` / `useRefSignalMemo` | Derived signals — recompute whenever deps change; module-scope or component-scoped |
 | `watch(signal, listener, options?)` | Subscribe outside React and get a cleanup function back — mirrors `useEffect` return pattern; accepts the same `filter` and timing options as the hooks |
 | `EffectOptions` | Gate and rate-limit re-renders and effects via `filter`, `throttle`, `debounce`, `maxWait`, or `rAF` |
+| `createPulseRefSignal` / `usePulseRefSignal` | A signal that ticks on a schedule — `'1000ms'`, `'60fps'`, `'raf'`. Lazy: the timer runs only while subscribed. Carries `dt`, `tick`, `elapsed` metadata |
+| `updatePulse(rate)` | Change a pulse signal's cadence reactively — drive it from another signal for adaptive heartbeats, backoff, perf-budgeted frames |
 | `createRefSignalStore` / `useRefSignalStore` | Provider-free global store — create at module scope, use in any component with `renderOn` opt-in |
 | `createRefSignalContext` | Per-subtree store with auto-generated Provider and hook — for isolated state per route or section |
 | Signal lifetime | Listeners are in a `WeakMap` — GC'd when the signal has no references |
@@ -179,7 +240,7 @@ Use `createRefSignalContext` instead when you need per-subtree isolation — a s
 | Redux | No | Selector-based | Narrowable via selector, but always renders |
 | `useRef` (plain React) | N/A | None | No subscription possible |
 
-react-refsignal is the only entry that can subscribe to a value via a stable React API and not re-render at all.
+react-refsignal is the only entry that can subscribe to a value via a stable React API and not re-render at all. It's also the only entry where each consumer picks its own subscription rate — synchronous, `throttle`, `debounce`, `rAF`, or a custom `filter` — at the call site, independently of the producer.
 
 **The closest alternative is @preact/signals-react.** Both libraries let you update values outside React's render cycle and subscribe to those updates. The difference is how:
 

--- a/demo/agents.tsx
+++ b/demo/agents.tsx
@@ -1,0 +1,1320 @@
+// demo/agents.tsx
+//
+// Automated agar.io-style chase/flee simulation. Permadeath — last one standing
+// wins. The actual signal demo:
+//
+//   - Each agent owns position / size / alive / callTarget signals.
+//   - SVG circles update via per-signal `useRefSignalEffect` — no React renders
+//     in the per-frame path.
+//   - Six independent reactive consumers each subscribe to ONLY the signals they
+//     care about: alive count, biggest badge, calls count, leaderboard, team
+//     scoreboard, killcam feed, winner banner. None of them re-render on
+//     simulation ticks unless their slice of state actually changed.
+//   - Inter-agent coordination via signals: each agent broadcasts its current
+//     target via `callTarget`. Same-team allies within HEARING radius adopt
+//     the call when they lack a target of their own — pack-hunting emerges.
+//     The CallLines layer follows each call with `trackSignals` so when an
+//     agent's callTarget changes, the line subscription swaps to the new
+//     target's position signal automatically.
+//
+// This is what signals are actually for: heterogeneous fanout of changes to
+// different consumers without a central re-render or manual invalidation,
+// plus declarative cross-entity communication without a central event bus.
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  batch,
+  createRefSignal,
+  usePulseRefSignal,
+  useRefSignalEffect,
+  useRefSignalRender,
+  type RefSignal,
+} from 'react-refsignal';
+import { FpsBadge } from './fps';
+
+// ---------------------------------------------------------------
+// Types & config
+// ---------------------------------------------------------------
+
+type Vec = { x: number; y: number };
+
+type Agent = {
+  id: number;
+  team: number;
+  hue: number;
+  name: string;
+  position: RefSignal<Vec>;
+  size: RefSignal<number>;
+  alive: RefSignal<boolean>;
+  vx: number;
+  vy: number;
+  kills: number;
+  // Tracked across ticks to avoid flip-flop between equidistant candidates —
+  // each agent sticks with its current target/threat as long as it remains valid.
+  targetId: number | null;
+  threatId: number | null;
+  // Public broadcast of "the target I've committed to." Same-team allies within
+  // HEARING radius can adopt this when they have no target of their own. Pack
+  // hunting emerges as the call propagates outward each tick.
+  callTarget: RefSignal<number | null>;
+};
+
+type Pellet = {
+  id: number;
+  x: number;
+  y: number;
+  alive: RefSignal<boolean>;
+  deadTicks: number;
+};
+
+type KillEvent = {
+  killerId: number;
+  killerName: string;
+  killerHue: number;
+  victimName: string;
+  victimHue: number;
+};
+
+type ControlState = {
+  agentId: number | null;
+  mouse: Vec;
+};
+
+const COUNTS = [60, 120, 180, 240, 360] as const;
+type Count = (typeof COUNTS)[number];
+const DEFAULT_COUNT: Count = 120;
+const TEAM_HUES = [10, 50, 140, 220];
+const TEAM_NAMES = ['Crimson', 'Solar', 'Forest', 'Tide'];
+const N_TEAMS = TEAM_NAMES.length;
+const VISION = 220;
+const HEARING = 320; // teammate-call propagation radius — wider than vision so calls inform agents that don't see the prey themselves
+const BASE_SPEED = 2.2;
+const MIN_SIZE = 4;
+const SIZE_THRESHOLD = 1.15;
+const MASS_GAIN = 0.7;
+const PELLET_RESPAWN_TICKS = 240;
+const PELLET_VALUE = 0.7;
+const KILLCAM_MAX = 6;
+const GRID_CELL = 80; // spatial-hash cell size — tuned so VISION (220) covers ~3 cells
+const TURN_RATE = 0.15; // steering inertia (0 = no turn, 1 = instant turn)
+
+const ADJ = [
+  'Swift', 'Brave', 'Sneaky', 'Wild', 'Clever', 'Bold', 'Sly', 'Fierce',
+  'Cosmic', 'Thunder', 'Iron', 'Storm', 'Shadow', 'Crystal', 'Nimble',
+];
+const NOUN = [
+  'Fox', 'Wolf', 'Hawk', 'Bear', 'Tiger', 'Owl', 'Cobra', 'Falcon',
+  'Lynx', 'Raven', 'Lion', 'Shark', 'Eagle', 'Panther', 'Drake',
+];
+
+// Killcam feed — one RefSignal holding the last N kills. Subscribed by the
+// Killcam component and (transitively) the leaderboard's "kills" stat.
+const killFeed = createRefSignal<KillEvent[]>([]);
+
+// Module-scope simulation speed (ticks/sec target). The slider component
+// subscribes via useRefSignalRender; the RAF loop reads `.current` directly
+// without re-subscribing — changing speed never restarts the loop.
+const tickSpeed = createRefSignal<number>(60);
+
+function pushKill(ev: KillEvent) {
+  killFeed.update([ev, ...killFeed.current].slice(0, KILLCAM_MAX));
+}
+
+// ---------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------
+
+function radiusOf(size: number): number {
+  return Math.sqrt(size) * 2.6;
+}
+
+function rand(min: number, max: number): number {
+  return min + Math.random() * (max - min);
+}
+
+function pick<T>(arr: readonly T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function makeAgent(id: number, world: Vec): Agent {
+  const team = id % N_TEAMS;
+  const baseHue = TEAM_HUES[team];
+  // Slight per-agent jitter within team color band.
+  const hue = (baseHue + rand(-12, 12) + 360) % 360;
+  return {
+    id,
+    team,
+    hue,
+    name: `${pick(ADJ)}${pick(NOUN)}`,
+    position: createRefSignal<Vec>({
+      x: rand(40, world.x - 40),
+      y: rand(40, world.y - 40),
+    }),
+    size: createRefSignal(rand(MIN_SIZE, MIN_SIZE + 6)),
+    alive: createRefSignal(true),
+    vx: rand(-1, 1),
+    vy: rand(-1, 1),
+    kills: 0,
+    targetId: null,
+    threatId: null,
+    callTarget: createRefSignal<number | null>(null),
+  };
+}
+
+function makePellet(id: number, world: Vec): Pellet {
+  return {
+    id,
+    x: rand(20, world.x - 20),
+    y: rand(20, world.y - 20),
+    alive: createRefSignal(true),
+    deadTicks: 0,
+  };
+}
+
+// ---------------------------------------------------------------
+// Tick
+// ---------------------------------------------------------------
+
+type TickResult = { gameOver: boolean; survivor: Agent | null };
+
+function tryEat(a: Agent, b: Agent) {
+  const ap = a.position.current;
+  const bp = b.position.current;
+  const aSize = a.size.current;
+  const bSize = b.size.current;
+  const ar = radiusOf(aSize);
+  const br = radiusOf(bSize);
+  const dx = ap.x - bp.x;
+  const dy = ap.y - bp.y;
+  const d2 = dx * dx + dy * dy;
+  const eatD = Math.max(ar, br) * 0.6;
+  if (d2 >= eatD * eatD) return;
+  if (aSize > bSize * SIZE_THRESHOLD) {
+    a.size.update(aSize + bSize * MASS_GAIN);
+    b.alive.update(false);
+    b.callTarget.update(null);
+    a.kills++;
+    pushKill({
+      killerId: a.id, killerName: a.name, killerHue: a.hue,
+      victimName: b.name, victimHue: b.hue,
+    });
+  } else if (bSize > aSize * SIZE_THRESHOLD) {
+    b.size.update(bSize + aSize * MASS_GAIN);
+    a.alive.update(false);
+    a.callTarget.update(null);
+    b.kills++;
+    pushKill({
+      killerId: b.id, killerName: b.name, killerHue: b.hue,
+      victimName: a.name, victimHue: a.hue,
+    });
+  }
+}
+
+function tick(
+  agents: Agent[],
+  pellets: Pellet[],
+  world: Vec,
+  control: ControlState,
+): TickResult {
+  // ─── Spatial hash: bucket alive agents + pellets into a coarse grid. ───
+  // AI and collision queries become O(local density) instead of O(N).
+  const cw = ((world.x / GRID_CELL) | 0) + 2;
+  const ch = ((world.y / GRID_CELL) | 0) + 2;
+  const total = cw * ch;
+  const aGrid: Agent[][] = new Array(total);
+  const pGrid: Pellet[][] = new Array(total);
+  for (let i = 0; i < total; i++) { aGrid[i] = []; pGrid[i] = []; }
+
+  const cellAt = (x: number, y: number) => {
+    let cx = (x / GRID_CELL) | 0;
+    let cy = (y / GRID_CELL) | 0;
+    if (cx < 0) cx = 0; else if (cx >= cw) cx = cw - 1;
+    if (cy < 0) cy = 0; else if (cy >= ch) cy = ch - 1;
+    return cy * cw + cx;
+  };
+
+  for (const a of agents) {
+    if (!a.alive.current) continue;
+    const p = a.position.current;
+    aGrid[cellAt(p.x, p.y)].push(a);
+  }
+  for (const p of pellets) {
+    if (!p.alive.current) continue;
+    pGrid[cellAt(p.x, p.y)].push(p);
+  }
+
+  const visionRad = Math.ceil(VISION / GRID_CELL);
+  const visionD2 = VISION * VISION;
+  const hearingRad = Math.ceil(HEARING / GRID_CELL);
+  const hearingD2 = HEARING * HEARING;
+
+  let aliveCount = 0;
+  let last: Agent | null = null;
+
+  batch(() => {
+    // ─── 1. AI + physics ──────────────────────────────────────────────
+    for (const a of agents) {
+      if (!a.alive.current) continue;
+      aliveCount++;
+      last = a;
+
+      const ap = a.position.current;
+      const aSize = a.size.current;
+      const speed = BASE_SPEED / Math.sqrt(Math.max(1, aSize / 5));
+
+      // ── Player control: bypass AI entirely. ──────────────────────────
+      // Controlled agent steers toward the mouse cursor. No automatic
+      // threat avoidance — getting eaten is the player's responsibility.
+      if (control.agentId === a.id) {
+        a.targetId = null;
+        a.threatId = null;
+        a.callTarget.update(null);
+        const ddx = control.mouse.x - ap.x;
+        const ddy = control.mouse.y - ap.y;
+        const dlen = Math.hypot(ddx, ddy) || 1;
+        const desVx = (ddx / dlen) * speed;
+        const desVy = (ddy / dlen) * speed;
+        const sVx = a.vx * (1 - TURN_RATE) + desVx * TURN_RATE;
+        const sVy = a.vy * (1 - TURN_RATE) + desVy * TURN_RATE;
+        const sLen = Math.hypot(sVx, sVy) || 1;
+        a.vx = (sVx / sLen) * speed;
+        a.vy = (sVy / sLen) * speed;
+        let nx = ap.x + a.vx;
+        let ny = ap.y + a.vy;
+        if (nx < 0) { nx = 0; a.vx = Math.abs(a.vx); }
+        else if (nx > world.x) { nx = world.x; a.vx = -Math.abs(a.vx); }
+        if (ny < 0) { ny = 0; a.vy = Math.abs(a.vy); }
+        else if (ny > world.y) { ny = world.y; a.vy = -Math.abs(a.vy); }
+        a.position.update({ x: nx, y: ny });
+        continue;
+      }
+
+      const acx = (ap.x / GRID_CELL) | 0;
+      const acy = (ap.y / GRID_CELL) | 0;
+
+      // ── Persistence: keep last tick's target/threat if still valid. ──
+      // This is the main fix for "bouncing": instead of re-picking from
+      // scratch each tick (which flip-flops between equidistant candidates),
+      // we stick with the current pick until it dies, leaves vision, or
+      // ceases to satisfy the size threshold.
+      let target: Agent | null = null;
+      let threat: Agent | null = null;
+
+      if (a.targetId !== null) {
+        const c = agents[a.targetId];
+        if (c && c.alive.current && aSize > c.size.current * SIZE_THRESHOLD) {
+          const cp = c.position.current;
+          const cdx = cp.x - ap.x;
+          const cdy = cp.y - ap.y;
+          if (cdx * cdx + cdy * cdy <= visionD2) target = c;
+        }
+      }
+      if (a.threatId !== null) {
+        const c = agents[a.threatId];
+        if (c && c.alive.current && c.size.current > aSize * SIZE_THRESHOLD) {
+          const cp = c.position.current;
+          const cdx = cp.x - ap.x;
+          const cdy = cp.y - ap.y;
+          if (cdx * cdx + cdy * cdy <= visionD2) threat = c;
+        }
+      }
+
+      // Scan grid for new target/threat only if needed.
+      if (!target || !threat) {
+        let bestTargetD2 = Infinity;
+        let bestThreatD2 = Infinity;
+        const xLo = Math.max(0, acx - visionRad);
+        const xHi = Math.min(cw - 1, acx + visionRad);
+        const yLo = Math.max(0, acy - visionRad);
+        const yHi = Math.min(ch - 1, acy + visionRad);
+        for (let cy = yLo; cy <= yHi; cy++) {
+          for (let cx = xLo; cx <= xHi; cx++) {
+            const bucket = aGrid[cy * cw + cx];
+            for (let bi = 0; bi < bucket.length; bi++) {
+              const b = bucket[bi];
+              if (b === a) continue;
+              const bp = b.position.current;
+              const dxx = bp.x - ap.x;
+              const dyy = bp.y - ap.y;
+              const d2 = dxx * dxx + dyy * dyy;
+              if (d2 > visionD2) continue;
+              const bSize = b.size.current;
+              if (!target && aSize > bSize * SIZE_THRESHOLD) {
+                if (d2 < bestTargetD2) { target = b; bestTargetD2 = d2; }
+              } else if (!threat && bSize > aSize * SIZE_THRESHOLD) {
+                if (d2 < bestThreatD2) { threat = b; bestThreatD2 = d2; }
+              }
+            }
+          }
+        }
+      }
+      // Same-team call adoption — listen for nearby allies broadcasting a target.
+      // If we have no target of our own and no threat, adopt the closest hearable
+      // ally's call (prey must still pass our own size threshold). Calls then
+      // propagate as we re-broadcast below — pack-hunting emerges across the team.
+      if (!target && !threat) {
+        const xLo = Math.max(0, acx - hearingRad);
+        const xHi = Math.min(cw - 1, acx + hearingRad);
+        const yLo = Math.max(0, acy - hearingRad);
+        const yHi = Math.min(ch - 1, acy + hearingRad);
+        let bestD2 = Infinity;
+        for (let cy = yLo; cy <= yHi; cy++) {
+          for (let cx = xLo; cx <= xHi; cx++) {
+            const bucket = aGrid[cy * cw + cx];
+            for (let bi = 0; bi < bucket.length; bi++) {
+              const ally = bucket[bi];
+              if (ally === a || ally.team !== a.team) continue;
+              const aap = ally.position.current;
+              const ddx = aap.x - ap.x;
+              const ddy = aap.y - ap.y;
+              const d2 = ddx * ddx + ddy * ddy;
+              if (d2 > hearingD2 || d2 >= bestD2) continue;
+              const calledId = ally.callTarget.current;
+              if (calledId === null) continue;
+              const called = agents[calledId];
+              if (!called || !called.alive.current) continue;
+              if (aSize <= called.size.current * SIZE_THRESHOLD) continue;
+              target = called;
+              bestD2 = d2;
+            }
+          }
+        }
+      }
+
+      a.targetId = target ? target.id : null;
+      a.threatId = threat ? threat.id : null;
+      // Broadcast the target only when actively hunting — never while fleeing
+      // (would propagate panic) and never when there's no target. `update()` is
+      // a no-op when the value is unchanged, so this is cheap each tick.
+      a.callTarget.update(!threat && target ? target.id : null);
+
+      // Pellet seek when no agent priority.
+      let pelletT: Pellet | null = null;
+      if (!threat && !target) {
+        let pelletD2 = Infinity;
+        const xLo = Math.max(0, acx - visionRad);
+        const xHi = Math.min(cw - 1, acx + visionRad);
+        const yLo = Math.max(0, acy - visionRad);
+        const yHi = Math.min(ch - 1, acy + visionRad);
+        for (let cy = yLo; cy <= yHi; cy++) {
+          for (let cx = xLo; cx <= xHi; cx++) {
+            const bucket = pGrid[cy * cw + cx];
+            for (let bi = 0; bi < bucket.length; bi++) {
+              const p = bucket[bi];
+              const dxx = p.x - ap.x;
+              const dyy = p.y - ap.y;
+              const d2 = dxx * dxx + dyy * dyy;
+              if (d2 > visionD2) continue;
+              if (d2 < pelletD2) { pelletT = p; pelletD2 = d2; }
+            }
+          }
+        }
+      }
+
+      // Desired heading.
+      let ddx: number;
+      let ddy: number;
+      if (threat) {
+        const tp = threat.position.current;
+        ddx = ap.x - tp.x;
+        ddy = ap.y - tp.y;
+      } else if (target) {
+        const tp = target.position.current;
+        ddx = tp.x - ap.x;
+        ddy = tp.y - ap.y;
+      } else if (pelletT) {
+        ddx = pelletT.x - ap.x;
+        ddy = pelletT.y - ap.y;
+      } else {
+        ddx = a.vx + rand(-0.4, 0.4);
+        ddy = a.vy + rand(-0.4, 0.4);
+      }
+
+      const dlen = Math.hypot(ddx, ddy) || 1;
+      const desVx = (ddx / dlen) * speed;
+      const desVy = (ddy / dlen) * speed;
+
+      // Steering inertia: blend toward desired velocity. Smooths out
+      // direction flips and removes the "bouncing" feel for agents
+      // hesitating between candidates.
+      const sVx = a.vx * (1 - TURN_RATE) + desVx * TURN_RATE;
+      const sVy = a.vy * (1 - TURN_RATE) + desVy * TURN_RATE;
+      const sLen = Math.hypot(sVx, sVy) || 1;
+      a.vx = (sVx / sLen) * speed;
+      a.vy = (sVy / sLen) * speed;
+
+      let nx = ap.x + a.vx;
+      let ny = ap.y + a.vy;
+      if (nx < 0) { nx = 0; a.vx = Math.abs(a.vx); }
+      else if (nx > world.x) { nx = world.x; a.vx = -Math.abs(a.vx); }
+      if (ny < 0) { ny = 0; a.vy = Math.abs(a.vy); }
+      else if (ny > world.y) { ny = world.y; a.vy = -Math.abs(a.vy); }
+      a.position.update({ x: nx, y: ny });
+    }
+
+    // ─── 2. Agent-agent collisions via grid. ──────────────────────────
+    // For each cell: pairs within + pairs with 4 "later" neighbor cells.
+    for (let cy = 0; cy < ch; cy++) {
+      for (let cx = 0; cx < cw; cx++) {
+        const bucket = aGrid[cy * cw + cx];
+        for (let i = 0; i < bucket.length; i++) {
+          const a = bucket[i];
+          if (!a.alive.current) continue;
+          for (let j = i + 1; j < bucket.length; j++) {
+            const b = bucket[j];
+            if (!b.alive.current) continue;
+            tryEat(a, b);
+            if (!a.alive.current) break;
+          }
+        }
+        // 4 neighbors: E, SW, S, SE — covers each pair exactly once.
+        const neigh: [number, number][] = [[1, 0], [-1, 1], [0, 1], [1, 1]];
+        for (let n = 0; n < neigh.length; n++) {
+          const ncx = cx + neigh[n][0];
+          const ncy = cy + neigh[n][1];
+          if (ncx < 0 || ncx >= cw || ncy < 0 || ncy >= ch) continue;
+          const nbucket = aGrid[ncy * cw + ncx];
+          for (let i = 0; i < bucket.length; i++) {
+            const a = bucket[i];
+            if (!a.alive.current) continue;
+            for (let j = 0; j < nbucket.length; j++) {
+              const b = nbucket[j];
+              if (!b.alive.current) continue;
+              tryEat(a, b);
+              if (!a.alive.current) break;
+            }
+          }
+        }
+      }
+    }
+
+    // ─── 3. Agent-pellet collisions via grid (3x3). ───────────────────
+    for (const a of agents) {
+      if (!a.alive.current) continue;
+      const ap = a.position.current;
+      const acx = (ap.x / GRID_CELL) | 0;
+      const acy = (ap.y / GRID_CELL) | 0;
+      const ar = radiusOf(a.size.current);
+      const ar2 = ar * ar;
+      const xLo = Math.max(0, acx - 1);
+      const xHi = Math.min(cw - 1, acx + 1);
+      const yLo = Math.max(0, acy - 1);
+      const yHi = Math.min(ch - 1, acy + 1);
+      for (let cy = yLo; cy <= yHi; cy++) {
+        for (let cx = xLo; cx <= xHi; cx++) {
+          const bucket = pGrid[cy * cw + cx];
+          for (let bi = 0; bi < bucket.length; bi++) {
+            const p = bucket[bi];
+            if (!p.alive.current) continue;
+            const dxx = ap.x - p.x;
+            const dyy = ap.y - p.y;
+            if (dxx * dxx + dyy * dyy < ar2) {
+              a.size.update(a.size.current + PELLET_VALUE);
+              p.alive.update(false);
+              p.deadTicks = 0;
+            }
+          }
+        }
+      }
+    }
+
+    // ─── 4. Pellet respawn. ───────────────────────────────────────────
+    for (const p of pellets) {
+      if (p.alive.current) continue;
+      p.deadTicks++;
+      if (p.deadTicks >= PELLET_RESPAWN_TICKS) {
+        p.x = rand(20, world.x - 20);
+        p.y = rand(20, world.y - 20);
+        p.deadTicks = 0;
+        p.alive.update(true);
+      }
+    }
+  });
+
+  return { gameOver: aliveCount <= 1, survivor: aliveCount === 1 ? last : null };
+}
+
+// ---------------------------------------------------------------
+// AgentDot — vision ring + body + name. Three per-signal effects.
+// ---------------------------------------------------------------
+
+function AgentDot({ agent, showName, showVision, controlled, onTakeControl }: {
+  agent: Agent;
+  showName: boolean;
+  showVision: boolean;
+  controlled: boolean;
+  onTakeControl: (id: number) => void;
+}) {
+  const gRef = useRef<SVGGElement>(null);
+  const bodyRef = useRef<SVGCircleElement>(null);
+  const textRef = useRef<SVGTextElement>(null);
+  const haloRef = useRef<SVGCircleElement>(null);
+  const fill = `hsl(${agent.hue} 75% 55%)`;
+  const stroke = `hsl(${agent.hue} 60% 30%)`;
+  const initialP = agent.position.current;
+  const initialR = radiusOf(agent.size.current);
+
+  useRefSignalEffect(() => {
+    const g = gRef.current;
+    if (!g) return;
+    const p = agent.position.current;
+    g.setAttribute('transform', `translate(${p.x.toFixed(1)},${p.y.toFixed(1)})`);
+  }, [agent.position]);
+
+  useRefSignalEffect(() => {
+    const r = radiusOf(agent.size.current);
+    bodyRef.current?.setAttribute('r', r.toFixed(1));
+    textRef.current?.setAttribute('y', String(-(r + 4)));
+    haloRef.current?.setAttribute('r', (r + 8).toFixed(1));
+  }, [agent.size]);
+
+  useRefSignalEffect(() => {
+    const g = gRef.current;
+    if (g) g.style.opacity = agent.alive.current ? '1' : '0';
+  }, [agent.alive]);
+
+  return (
+    <g
+      ref={gRef}
+      transform={`translate(${initialP.x},${initialP.y})`}
+      style={{ cursor: 'pointer' }}
+      onPointerDown={(e) => {
+        e.stopPropagation();
+        onTakeControl(agent.id);
+      }}
+    >
+      {showVision && (
+        <circle
+          r={VISION}
+          fill="none"
+          stroke={fill}
+          strokeOpacity={0.04}
+          strokeWidth={1}
+        />
+      )}
+      {controlled && (
+        <circle
+          ref={haloRef}
+          r={initialR + 8}
+          fill="none"
+          stroke="#fff"
+          strokeOpacity={0.7}
+          strokeWidth={2}
+          pointerEvents="none"
+        />
+      )}
+      <circle
+        ref={bodyRef}
+        r={initialR}
+        fill={fill}
+        stroke={controlled ? '#fff' : stroke}
+        strokeWidth={controlled ? 2.5 : 1.5}
+      />
+      {showName && (
+        <text
+          ref={textRef}
+          y={-(initialR + 4)}
+          textAnchor="middle"
+          fontSize={9}
+          fontFamily="system-ui, sans-serif"
+          fontWeight={600}
+          fill="rgba(255,255,255,0.85)"
+          stroke="rgba(0,0,0,0.5)"
+          strokeWidth={2}
+          paintOrder="stroke"
+          pointerEvents="none"
+        >
+          {agent.name}
+        </text>
+      )}
+    </g>
+  );
+}
+
+// ---------------------------------------------------------------
+// PelletDot — minimal: opacity flip on alive change, cx/cy move on respawn.
+// ---------------------------------------------------------------
+
+function PelletDot({ pellet }: { pellet: Pellet }) {
+  const ref = useRef<SVGCircleElement>(null);
+
+  useRefSignalEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.opacity = pellet.alive.current ? '1' : '0';
+    // On respawn, x/y were mutated before alive flipped to true — reflect them.
+    el.setAttribute('cx', String(pellet.x));
+    el.setAttribute('cy', String(pellet.y));
+  }, [pellet.alive]);
+
+  return (
+    <circle
+      ref={ref}
+      cx={pellet.x}
+      cy={pellet.y}
+      r={2.5}
+      fill="rgba(255, 220, 100, 0.85)"
+    />
+  );
+}
+
+// ---------------------------------------------------------------
+// CallLines — one <line> per agent, drawn while that agent is broadcasting
+// a call. Each line follows the caller's position, the call signal, and the
+// CALLED target's position — the last of which has dynamic identity (it
+// changes whenever the agent re-targets), so we use `trackSignals` to
+// re-subscribe automatically. This is the inter-agent comms made visible.
+// ---------------------------------------------------------------
+
+function CallLines({ agents }: { agents: Agent[] }) {
+  return (
+    <g>
+      {agents.map((a) => (
+        <CallLine key={a.id} agent={a} agents={agents} />
+      ))}
+    </g>
+  );
+}
+
+function CallLine({ agent, agents }: { agent: Agent; agents: Agent[] }) {
+  const ref = useRef<SVGLineElement>(null);
+
+  useRefSignalEffect(
+    () => {
+      const el = ref.current;
+      if (!el) return;
+      const targetId = agent.callTarget.current;
+      if (targetId === null || !agent.alive.current) {
+        el.style.display = 'none';
+        return;
+      }
+      const target = agents[targetId];
+      if (!target || !target.alive.current) {
+        el.style.display = 'none';
+        return;
+      }
+      const ap = agent.position.current;
+      const tp = target.position.current;
+      el.style.display = '';
+      el.setAttribute('x1', ap.x.toFixed(1));
+      el.setAttribute('y1', ap.y.toFixed(1));
+      el.setAttribute('x2', tp.x.toFixed(1));
+      el.setAttribute('y2', tp.y.toFixed(1));
+      el.setAttribute('stroke', `hsl(${agent.hue} 70% 60%)`);
+    },
+    [agent.callTarget, agent.position, agent.alive],
+    {
+      // Dynamic dep — when callTarget swaps, the subscription follows the new
+      // target's position/alive without needing to tear down + recreate the effect.
+      trackSignals: () => {
+        const id = agent.callTarget.current;
+        if (id === null) return [];
+        const target = agents[id];
+        return target ? [target.position, target.alive] : [];
+      },
+    },
+  );
+
+  return (
+    <line
+      ref={ref}
+      stroke="white"
+      strokeOpacity={0.4}
+      strokeWidth={1.2}
+      strokeDasharray="3 4"
+      pointerEvents="none"
+      style={{ display: 'none' }}
+    />
+  );
+}
+
+// ---------------------------------------------------------------
+// Reactive consumers — each subscribes only to its slice.
+// ---------------------------------------------------------------
+
+function AliveCount({ agents }: { agents: Agent[] }) {
+  const sigs = useMemo(() => agents.map((a) => a.alive), [agents]);
+  useRefSignalRender(sigs, { rAF: true });
+  let n = 0;
+  for (const a of agents) if (a.alive.current) n++;
+  return <Stat label="alive" value={`${n}/${agents.length}`} />;
+}
+
+function BiggestBadge({ agents }: { agents: Agent[] }) {
+  const sigs = useMemo(
+    () => agents.flatMap((a) => [a.size, a.alive]),
+    [agents],
+  );
+  useRefSignalRender(sigs, { rAF: true });
+  let max = 0;
+  for (const a of agents) {
+    if (a.alive.current && a.size.current > max) max = a.size.current;
+  }
+  return <Stat label="biggest" value={max.toFixed(1)} highlight />;
+}
+
+function CallsCount({ agents }: { agents: Agent[] }) {
+  // Subscribes only to the callTarget slice — re-renders when agents start
+  // or stop broadcasting, never on plain position updates.
+  const sigs = useMemo(() => agents.map((a) => a.callTarget), [agents]);
+  useRefSignalRender(sigs, { rAF: true });
+  let n = 0;
+  for (const a of agents) if (a.alive.current && a.callTarget.current !== null) n++;
+  return <Stat label="calls" value={n} />;
+}
+
+function Leaderboard({ agents }: { agents: Agent[] }) {
+  const sigs = useMemo(
+    () => agents.flatMap((a) => [a.size, a.alive]),
+    [agents],
+  );
+  useRefSignalRender(sigs, { rAF: true });
+  // Re-sort top-5 in the body. Cheap at N=60.
+  const top = [...agents]
+    .filter((a) => a.alive.current)
+    .sort((a, b) => b.size.current - a.size.current)
+    .slice(0, 5);
+
+  return (
+    <div style={panelStyle('top', 12)}>
+      <div style={panelHeading}>TOP 5</div>
+      {top.map((a, i) => (
+        <div key={a.id} style={leaderRow}>
+          <span style={rankCell}>#{i + 1}</span>
+          <Dot hue={a.hue} />
+          <span style={{ fontSize: 11, opacity: 0.85, flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {a.name}
+          </span>
+          <span style={{ fontFamily: 'monospace', fontSize: 11 }}>
+            {a.size.current.toFixed(1)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TeamScoreboard({ agents }: { agents: Agent[] }) {
+  return (
+    <div style={panelStyle('left', 12)}>
+      <div style={panelHeading}>TEAMS</div>
+      {Array.from({ length: N_TEAMS }, (_, t) => (
+        <TeamRow key={t} team={t} agents={agents} />
+      ))}
+    </div>
+  );
+}
+
+function TeamRow({ team, agents }: { team: number; agents: Agent[] }) {
+  const teamAgents = useMemo(
+    () => agents.filter((a) => a.team === team),
+    [agents, team],
+  );
+  const sigs = useMemo(
+    () => teamAgents.flatMap((a) => [a.size, a.alive]),
+    [teamAgents],
+  );
+  // KEY POINT: this row only re-renders when its own team's signals fire.
+  // Other teams' changes don't trigger anything here.
+  useRefSignalRender(sigs, { rAF: true });
+
+  let alive = 0;
+  let mass = 0;
+  for (const a of teamAgents) {
+    if (a.alive.current) {
+      alive++;
+      mass += a.size.current;
+    }
+  }
+  const eliminated = alive === 0;
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        padding: '3px 0',
+        opacity: eliminated ? 0.3 : 1,
+        textDecoration: eliminated ? 'line-through' : 'none',
+      }}
+    >
+      <span
+        style={{
+          width: 10,
+          height: 10,
+          borderRadius: 2,
+          background: `hsl(${TEAM_HUES[team]} 70% 55%)`,
+        }}
+      />
+      <span style={{ fontSize: 11, flex: 1 }}>{TEAM_NAMES[team]}</span>
+      <span style={{ fontFamily: 'monospace', fontSize: 11, opacity: 0.7, minWidth: 30, textAlign: 'right' }}>
+        {alive}/{teamAgents.length}
+      </span>
+      <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#4a9eff', minWidth: 36, textAlign: 'right' }}>
+        {mass.toFixed(0)}
+      </span>
+    </div>
+  );
+}
+
+function Killcam() {
+  // Subscribes only to the killFeed signal — re-renders only on kills.
+  useRefSignalRender([killFeed]);
+  const events = killFeed.current;
+
+  return (
+    <div style={panelStyle('bottom-right', 12)}>
+      <div style={panelHeading}>FEED</div>
+      {events.length === 0 ? (
+        <div style={{ opacity: 0.35, fontSize: 11, fontStyle: 'italic' }}>
+          No casualties yet
+        </div>
+      ) : (
+        events.map((e, i) => (
+          <div key={`${e.killerId}-${i}-${e.victimName}`} style={killRow}>
+            <Dot hue={e.killerHue} />
+            <span style={{ fontSize: 11 }}>{e.killerName}</span>
+            <span style={{ opacity: 0.4, fontSize: 10 }}>ate</span>
+            <Dot hue={e.victimHue} />
+            <span style={{ fontSize: 11, opacity: 0.7 }}>{e.victimName}</span>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+function WinnerBanner({ winner, onReset }: { winner: Agent; onReset: () => void }) {
+  // Subscribe to the winner's size in case mass keeps creeping from pellets.
+  useRefSignalRender([winner.size]);
+  return (
+    <div style={winnerOverlayStyle}>
+      <div style={winnerCardStyle}>
+        <div style={{ fontSize: 12, opacity: 0.55, letterSpacing: 1 }}>WINNER</div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginTop: 8 }}>
+          <span
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: '50%',
+              background: `hsl(${winner.hue} 75% 55%)`,
+              border: `2px solid hsl(${winner.hue} 60% 30%)`,
+            }}
+          />
+          <div>
+            <div style={{ fontSize: 22, fontWeight: 700 }}>{winner.name}</div>
+            <div style={{ fontSize: 12, opacity: 0.6 }}>
+              {TEAM_NAMES[winner.team]} · {winner.kills} kills · {winner.size.current.toFixed(1)} mass
+            </div>
+          </div>
+        </div>
+        <button onClick={onReset} style={{ ...btnStyle(false, '#10b981'), marginTop: 14 }}>
+          New round
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------
+
+export default function Agents() {
+  const [seed, setSeed] = useState(0);
+  const [count, setCount] = useState<Count>(DEFAULT_COUNT);
+  const [running, setRunning] = useState(true);
+  const [tickN, setTickN] = useState(0);
+  const [winner, setWinner] = useState<Agent | null>(null);
+  const [controlledId, setControlledId] = useState<number | null>(null);
+  // Mouse position in WORLD coords. Updated on every pointermove; read by
+  // tick() each frame. A ref (not state) — no re-renders on mouse motion.
+  const mouseRef = useRef<Vec>({ x: 0, y: 0 });
+
+  const stageRef = useRef<HTMLDivElement>(null);
+  const [world, setWorld] = useState<Vec>(() => ({
+    x: typeof window !== 'undefined' ? window.innerWidth - 32 : 1200,
+    y: typeof window !== 'undefined' ? window.innerHeight - 140 : 720,
+  }));
+
+  useEffect(() => {
+    const measure = () => {
+      const el = stageRef.current;
+      if (!el) return;
+      const r = el.getBoundingClientRect();
+      const x = Math.floor(r.width);
+      const y = Math.floor(r.height);
+      setWorld((prev) => (prev.x === x && prev.y === y ? prev : { x, y }));
+    };
+    const id = requestAnimationFrame(measure);
+    window.addEventListener('resize', measure);
+    return () => {
+      cancelAnimationFrame(id);
+      window.removeEventListener('resize', measure);
+    };
+  }, []);
+
+  // Pellets scale with agent count so density of food stays meaningful.
+  const pelletCount = count * 2;
+
+  // Recreate agents/pellets on count change, world change, OR reset (seed bump).
+  const agents = useMemo(
+    () => Array.from({ length: count }, (_, i) => makeAgent(i, world)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- seed deliberately invalidates the memo on reset
+    [count, world, seed],
+  );
+  const pellets = useMemo(
+    () => Array.from({ length: pelletCount }, (_, i) => makePellet(i, world)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [pelletCount, world, seed],
+  );
+
+  // Reset round-state when agents identity changes (count change, world resize, or reset).
+  useEffect(() => {
+    killFeed.update([]);
+    setWinner(null);
+    setTickN(0);
+    setRunning(true);
+    setControlledId(null);
+  }, [agents]);
+
+  // Auto-release control when the controlled agent dies.
+  useEffect(() => {
+    if (controlledId === null) return;
+    const a = agents[controlledId];
+    if (!a) return;
+    const listener = () => {
+      if (!a.alive.current) setControlledId(null);
+    };
+    a.alive.subscribe(listener);
+    return () => {
+      a.alive.unsubscribe(listener);
+    };
+  }, [controlledId, agents]);
+
+  // Tick loop. Stops on game over. Rate-gated by the module-scope `tickSpeed`
+  // signal — read directly inside the effect so speed changes don't restart
+  // the subscription (and don't need to be in the dep array).
+  const frame = usePulseRefSignal('raf');
+  const lastTickRef = useRef(0);
+  useEffect(() => {
+    if (!running || winner) return;
+    lastTickRef.current = 0;
+  }, [running, agents, pellets, world, winner, controlledId]);
+  useRefSignalEffect(
+    () => {
+      if (!running || winner) return;
+      const now = frame.elapsed;
+      const interval = 1000 / Math.max(1, tickSpeed.current);
+      if (now - lastTickRef.current >= interval) {
+        const result = tick(agents, pellets, world, {
+          agentId: controlledId,
+          mouse: mouseRef.current,
+        });
+        lastTickRef.current = now;
+        setTickN((n) => n + 1);
+        if (result.gameOver) {
+          setWinner(result.survivor);
+        }
+      }
+    },
+    [frame, running, agents, pellets, world, winner, controlledId],
+  );
+
+  const reset = () => setSeed((s) => s + 1);
+
+  return (
+    <div style={pageStyle}>
+      <div style={toolbarStyle}>
+        <button
+          onClick={() => setRunning((r) => !r)}
+          disabled={!!winner}
+          style={btnStyle(running && !winner, running ? '#f97316' : '#10b981')}
+        >
+          {running ? 'Pause' : 'Play'}
+        </button>
+        <button onClick={reset} style={btnStyle(false, '#64748b')}>
+          New round
+        </button>
+
+        <label style={sliderLabel}>
+          Agents
+          <select
+            value={count}
+            onChange={(e) => setCount(+e.target.value as Count)}
+            style={selectStyle}
+          >
+            {COUNTS.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <SpeedControl />
+
+        <span style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
+          {controlledId !== null && agents[controlledId] && (
+            <Stat label="control" value={agents[controlledId].name} highlight />
+          )}
+          <Stat label="tick" value={tickN} />
+          <AliveCount agents={agents} />
+          <BiggestBadge agents={agents} />
+          <CallsCount agents={agents} />
+          <FpsBadge />
+        </span>
+      </div>
+
+      <div style={hintStyle}>
+        {count} agents in 4 teams, permadeath. Bigger eats smaller (any team).
+        Pellets refill mass. <b>Click any agent to take control</b> — it&apos;ll steer
+        toward your cursor; auto-released when it dies. Each agent owns four signals
+        (<code style={codeStyle}>position</code>, <code style={codeStyle}>size</code>,{' '}
+        <code style={codeStyle}>alive</code>, <code style={codeStyle}>callTarget</code>)
+        — that&apos;s {count * 4} reactive cells. <b>Pack hunting via signals:</b> when
+        an agent locks a target it broadcasts via <code style={codeStyle}>callTarget</code>;
+        same-team allies within hearing range adopt the call when they have no target
+        of their own — propagating outward each tick. The dashed lines visualize
+        live calls; their subscriptions follow the called target dynamically via{' '}
+        <code style={codeStyle}>trackSignals</code>. The reactive panels each subscribe
+        only to their slice — TeamRows re-render only when their team changes; the
+        Killcam subscribes only to <code style={codeStyle}>killFeed</code>; no central
+        re-render anywhere.
+      </div>
+
+      <div ref={stageRef} style={{ flex: 1, overflow: 'hidden', position: 'relative' }}>
+        <svg
+          viewBox={`0 0 ${world.x} ${world.y}`}
+          preserveAspectRatio="none"
+          style={{
+            width: '100%',
+            height: '100%',
+            display: 'block',
+            cursor: controlledId !== null ? 'crosshair' : 'default',
+          }}
+          onPointerMove={(e) => {
+            const svg = e.currentTarget;
+            const rect = svg.getBoundingClientRect();
+            mouseRef.current = {
+              x: ((e.clientX - rect.left) / rect.width) * world.x,
+              y: ((e.clientY - rect.top) / rect.height) * world.y,
+            };
+          }}
+        >
+          {pellets.map((p) => (
+            <PelletDot key={p.id} pellet={p} />
+          ))}
+          <CallLines agents={agents} />
+          {agents.map((a) => (
+            <AgentDot
+              key={a.id}
+              agent={a}
+              showName={count <= 120}
+              showVision={count <= 120}
+              controlled={a.id === controlledId}
+              onTakeControl={setControlledId}
+            />
+          ))}
+        </svg>
+
+        <TeamScoreboard agents={agents} />
+        <Leaderboard agents={agents} />
+        <Killcam />
+
+        {winner && <WinnerBanner winner={winner} onReset={reset} />}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------
+// UI bits
+// ---------------------------------------------------------------
+
+// SpeedControl — controlled slider over the module-scope `tickSpeed` signal.
+// Re-renders only on speed changes (its own input or anything else updating
+// the signal). The RAF loop reads `tickSpeed.current` directly each frame.
+function SpeedControl() {
+  useRefSignalRender([tickSpeed]);
+  return (
+    <label style={sliderLabel}>
+      Speed
+      <input
+        type="range"
+        min={1}
+        max={120}
+        value={tickSpeed.current}
+        onChange={(e) => tickSpeed.update(+e.target.value)}
+        style={{ width: 100 }}
+      />
+      <span style={{ fontFamily: 'monospace', fontSize: 11, opacity: 0.7, minWidth: 36, textAlign: 'right' }}>
+        {tickSpeed.current}/s
+      </span>
+    </label>
+  );
+}
+
+function Dot({ hue }: { hue: number }) {
+  return (
+    <span
+      style={{
+        width: 10,
+        height: 10,
+        borderRadius: '50%',
+        background: `hsl(${hue} 70% 55%)`,
+        border: '1px solid rgba(0,0,0,0.4)',
+        flexShrink: 0,
+      }}
+    />
+  );
+}
+
+function Stat({ label, value, highlight }: { label: string; value: string | number; highlight?: boolean }) {
+  return (
+    <span style={{
+      background: '#0d1117',
+      padding: '4px 10px',
+      borderRadius: 4,
+      fontSize: 12,
+      fontFamily: 'monospace',
+      border: highlight ? '1px solid #4a9eff' : '1px solid transparent',
+    }}>
+      {label} <b style={{ color: highlight ? '#4a9eff' : '#fff' }}>{value}</b>
+    </span>
+  );
+}
+
+const pageStyle: React.CSSProperties = {
+  background: '#0a0d18',
+  color: '#fff',
+  height: '100vh',
+  display: 'flex',
+  flexDirection: 'column',
+  fontFamily: 'system-ui, sans-serif',
+  userSelect: 'none',
+};
+
+const toolbarStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '8px 14px',
+  background: '#16213e',
+  flexWrap: 'wrap',
+};
+
+const hintStyle: React.CSSProperties = {
+  padding: '4px 14px',
+  fontSize: 11,
+  opacity: 0.55,
+  background: '#16213e',
+  borderTop: '1px solid #1a1a2e',
+  lineHeight: 1.5,
+};
+
+const codeStyle: React.CSSProperties = {
+  padding: '1px 6px',
+  borderRadius: 3,
+  fontFamily: 'monospace',
+  fontSize: 11,
+  background: 'rgba(255,255,255,0.1)',
+};
+
+const sliderLabel: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 6,
+  fontSize: 12,
+  opacity: 0.85,
+};
+
+const selectStyle: React.CSSProperties = {
+  background: '#0d1117',
+  color: '#fff',
+  border: '1px solid #334155',
+  borderRadius: 4,
+  padding: '3px 6px',
+  fontSize: 12,
+};
+
+function panelStyle(corner: 'top' | 'left' | 'bottom-right', offset: number): React.CSSProperties {
+  const base: React.CSSProperties = {
+    position: 'absolute',
+    background: 'rgba(13, 17, 23, 0.85)',
+    backdropFilter: 'blur(8px)',
+    border: '1px solid rgba(255,255,255,0.08)',
+    borderRadius: 8,
+    padding: '10px 14px',
+    minWidth: 170,
+    boxShadow: '0 4px 16px rgba(0,0,0,0.4)',
+  };
+  if (corner === 'top') return { ...base, top: offset, right: offset };
+  if (corner === 'left') return { ...base, top: offset, left: offset };
+  return { ...base, bottom: offset, right: offset };
+}
+
+const panelHeading: React.CSSProperties = {
+  fontSize: 10,
+  opacity: 0.55,
+  marginBottom: 8,
+  letterSpacing: 1,
+  fontWeight: 700,
+};
+
+const leaderRow: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  marginBottom: 4,
+};
+
+const rankCell: React.CSSProperties = {
+  width: 14,
+  opacity: 0.5,
+  fontSize: 10,
+  fontFamily: 'monospace',
+};
+
+const killRow: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 6,
+  marginBottom: 3,
+};
+
+const winnerOverlayStyle: React.CSSProperties = {
+  position: 'absolute',
+  inset: 0,
+  background: 'rgba(0,0,0,0.55)',
+  backdropFilter: 'blur(2px)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 10,
+};
+
+const winnerCardStyle: React.CSSProperties = {
+  background: '#0d1117',
+  border: '1px solid rgba(255,255,255,0.1)',
+  borderRadius: 12,
+  padding: '24px 30px',
+  minWidth: 320,
+  boxShadow: '0 8px 32px rgba(0,0,0,0.6)',
+};
+
+function btnStyle(active: boolean, color: string): React.CSSProperties {
+  return {
+    padding: '5px 14px',
+    border: 'none',
+    borderRadius: 6,
+    cursor: 'pointer',
+    fontWeight: 600,
+    fontSize: 12,
+    background: active ? color : '#333',
+    color: '#fff',
+    opacity: active ? 1 : 0.75,
+    transition: 'opacity 0.15s',
+  };
+}

--- a/demo/fps.tsx
+++ b/demo/fps.tsx
@@ -1,0 +1,70 @@
+// demo/fps.tsx
+//
+// Reusable FPS badge — one shared pulse signal, one rounded-fps signal, any
+// number of consumers. Drop <FpsBadge /> anywhere; or call useFps() for custom
+// UI.
+//
+// The pulse subscription is ref-counted by consumer mounts: zero consumers ⇒
+// no watcher ⇒ pulse subscriber count stays at zero ⇒ pulse doesn't tick. The
+// first useFps() mount installs the watcher; the last unmount tears it down.
+
+import { useEffect } from 'react';
+import {
+  createPulseRefSignal,
+  createRefSignal,
+  useRefSignalRender,
+  watch,
+} from 'react-refsignal';
+
+const fpsSignal = createRefSignal(0);
+const frame = createPulseRefSignal('raf');
+
+let consumers = 0;
+let stopWatching: (() => void) | null = null;
+
+function startWatching(): () => void {
+  let frames = 0;
+  let lastSampleAt = 0;
+  return watch(frame, () => {
+    frames++;
+    const windowMs = frame.elapsed - lastSampleAt;
+    if (windowMs >= 1000) {
+      fpsSignal.update(Math.round((frames * 1000) / windowMs));
+      frames = 0;
+      lastSampleAt = frame.elapsed;
+    }
+  });
+}
+
+export function useFps(): number {
+  useEffect(() => {
+    if (consumers === 0) stopWatching = startWatching();
+    consumers++;
+    return () => {
+      consumers--;
+      if (consumers === 0) {
+        stopWatching?.();
+        stopWatching = null;
+      }
+    };
+  }, []);
+  useRefSignalRender([fpsSignal]);
+  return fpsSignal.current;
+}
+
+export function FpsBadge() {
+  const fps = useFps();
+  return (
+    <span style={badgeStyle}>
+      fps <b>{fps || '--'}</b>
+    </span>
+  );
+}
+
+const badgeStyle: React.CSSProperties = {
+  background: '#0d1117',
+  padding: '4px 10px',
+  borderRadius: 4,
+  fontSize: 12,
+  fontFamily: 'monospace',
+};

--- a/demo/game-of-life.tsx
+++ b/demo/game-of-life.tsx
@@ -1,0 +1,765 @@
+// demo/game-of-life.tsx
+//
+// Conway's Game of Life — one signal per cell, age-based coloring, batched ticks.
+//
+// What to watch:
+//   - Open React DevTools Profiler. Hit a pattern, run a tick.
+//   - Out of N×N cells, only the ~5–15% that *changed* re-render.
+//   - The "changed/tick" counter shows it live. That's the whole point.
+
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  batch,
+  createRefSignal,
+  usePulseRefSignal,
+  useRefSignalEffect,
+  type RefSignal,
+} from 'react-refsignal';
+import { FpsBadge } from './fps';
+
+// ---------------------------------------------------------------
+// Patterns
+// ---------------------------------------------------------------
+
+type Cells = [number, number][]; // [row, col]
+
+const GLIDER: Cells = [
+  [0, 1],
+  [1, 2],
+  [2, 0],
+  [2, 1],
+  [2, 2],
+];
+
+const PULSAR: Cells = [
+  [0, 2], [0, 3], [0, 4], [0, 8], [0, 9], [0, 10],
+  [2, 0], [2, 5], [2, 7], [2, 12],
+  [3, 0], [3, 5], [3, 7], [3, 12],
+  [4, 0], [4, 5], [4, 7], [4, 12],
+  [5, 2], [5, 3], [5, 4], [5, 8], [5, 9], [5, 10],
+  [7, 2], [7, 3], [7, 4], [7, 8], [7, 9], [7, 10],
+  [8, 0], [8, 5], [8, 7], [8, 12],
+  [9, 0], [9, 5], [9, 7], [9, 12],
+  [10, 0], [10, 5], [10, 7], [10, 12],
+  [12, 2], [12, 3], [12, 4], [12, 8], [12, 9], [12, 10],
+];
+
+const GOSPER: Cells = [
+  [4, 0], [4, 1], [5, 0], [5, 1],
+  [4, 10], [5, 10], [6, 10],
+  [3, 11], [7, 11],
+  [2, 12], [2, 13], [8, 12], [8, 13],
+  [5, 14],
+  [3, 15], [7, 15],
+  [4, 16], [5, 16], [6, 16],
+  [5, 17],
+  [2, 20], [3, 20], [4, 20],
+  [2, 21], [3, 21], [4, 21],
+  [1, 22], [5, 22],
+  [0, 24], [1, 24], [5, 24], [6, 24],
+  [2, 34], [2, 35], [3, 34], [3, 35],
+];
+
+const R_PENTOMINO: Cells = [
+  [0, 1], [0, 2],
+  [1, 0], [1, 1],
+  [2, 1],
+];
+
+type Pattern = { name: string; cells: Cells | 'random' };
+
+const PATTERNS: Pattern[] = [
+  { name: 'Glider',      cells: GLIDER },
+  { name: 'Pulsar',      cells: PULSAR },
+  { name: 'Gosper gun',  cells: GOSPER },
+  { name: 'R-pentomino', cells: R_PENTOMINO },
+  { name: 'Random 30%',  cells: 'random' },
+];
+
+// ---------------------------------------------------------------
+// Grid helpers
+// ---------------------------------------------------------------
+
+const SIZES = [40, 60, 80, 100] as const;
+type Size = (typeof SIZES)[number];
+
+const CELL_PX = [3, 4, 6, 8, 12] as const;
+type CellPx = (typeof CELL_PX)[number];
+
+function dimsOf(grid: RefSignal<number>[][]): { w: number; h: number } {
+  return { h: grid.length, w: grid[0]?.length ?? 0 };
+}
+
+function makeGrid(w: number, h: number): RefSignal<number>[][] {
+  // One signal per cell. Value is "age": 0 = dead, n > 0 = alive for n ticks.
+  const g: RefSignal<number>[][] = [];
+  for (let y = 0; y < h; y++) {
+    const row: RefSignal<number>[] = [];
+    for (let x = 0; x < w; x++) row.push(createRefSignal(0));
+    g.push(row);
+  }
+  return g;
+}
+
+function clearGrid(grid: RefSignal<number>[][]) {
+  batch(() => {
+    for (const row of grid) for (const sig of row) sig.update(0);
+  });
+}
+
+function placePattern(grid: RefSignal<number>[][], pattern: Pattern) {
+  const { w, h } = dimsOf(grid);
+  const cells = pattern.cells;
+  if (cells === 'random') {
+    batch(() => {
+      for (const row of grid) {
+        for (const sig of row) sig.update(Math.random() < 0.3 ? 1 : 0);
+      }
+    });
+    return;
+  }
+  const ys = cells.map((c) => c[0]);
+  const xs = cells.map((c) => c[1]);
+  const ph = Math.max(...ys) - Math.min(...ys);
+  const pw = Math.max(...xs) - Math.min(...xs);
+  const ox = Math.floor((w - pw) / 2) - Math.min(...xs);
+  const oy = Math.floor((h - ph) / 2) - Math.min(...ys);
+  batch(() => {
+    for (const row of grid) for (const sig of row) sig.update(0);
+    for (const [py, px] of cells) {
+      const x = px + ox;
+      const y = py + oy;
+      if (x >= 0 && x < w && y >= 0 && y < h) grid[y][x].update(1);
+    }
+  });
+}
+
+function tick(grid: RefSignal<number>[][]): { changed: number; alive: number } {
+  const { w, h } = dimsOf(grid);
+  // Read current state into a flat buffer (no signal subscriptions involved here).
+  const cur = new Uint8Array(w * h);
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      cur[y * w + x] = grid[y][x].current > 0 ? 1 : 0;
+    }
+  }
+  let changed = 0;
+  let alive = 0;
+  batch(() => {
+    for (let y = 0; y < h; y++) {
+      for (let x = 0; x < w; x++) {
+        let n = 0;
+        // Toroidal neighbourhood — wraps at edges.
+        for (let dy = -1; dy <= 1; dy++) {
+          for (let dx = -1; dx <= 1; dx++) {
+            if (dx === 0 && dy === 0) continue;
+            const nx = (x + dx + w) % w;
+            const ny = (y + dy + h) % h;
+            n += cur[ny * w + nx];
+          }
+        }
+        const wasAlive = cur[y * w + x] === 1;
+        const willBeAlive = wasAlive ? n === 2 || n === 3 : n === 3;
+        const oldAge = grid[y][x].current;
+        const newAge = willBeAlive ? oldAge + 1 : 0;
+        if (newAge !== oldAge) {
+          grid[y][x].update(newAge);
+          changed++;
+        }
+        if (willBeAlive) alive++;
+      }
+    }
+  });
+  return { changed, alive };
+}
+
+function patternFits(pattern: Pattern, w: number, h: number): boolean {
+  if (pattern.cells === 'random') return true;
+  const ys = pattern.cells.map((c) => c[0]);
+  const xs = pattern.cells.map((c) => c[1]);
+  return (
+    Math.max(...xs) - Math.min(...xs) < w &&
+    Math.max(...ys) - Math.min(...ys) < h
+  );
+}
+
+// ---------------------------------------------------------------
+// Coloring
+// ---------------------------------------------------------------
+
+const DEAD = '#0b0d18';
+const DEAD_RGB: [number, number, number] = [0x0b, 0x0d, 0x18];
+
+// Single source of truth for the age → HSL mapping.
+function hslAtAge(age: number): { h: number; s: number; l: number } {
+  // Sweep from cyan (newborn) → green → yellow → orange → red (old).
+  const t = Math.min(1, age / 30);
+  return {
+    h: 190 - t * 190,
+    s: 85,
+    l: 45 + (1 - t) * 15,
+  };
+}
+
+function ageColor(age: number): string {
+  if (age === 0) return DEAD;
+  const { h, s, l } = hslAtAge(age);
+  return `hsl(${h.toFixed(0)}, ${s}%, ${l.toFixed(0)}%)`;
+}
+
+// HSL → RGB (h: 0-360, s/l: 0-100), returns 0-255 ints.
+function hslToRgb(h: number, s: number, l: number): [number, number, number] {
+  const sN = s / 100;
+  const lN = l / 100;
+  const c = (1 - Math.abs(2 * lN - 1)) * sN;
+  const hp = h / 60;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  let r = 0, g = 0, b = 0;
+  if (hp < 1) [r, g, b] = [c, x, 0];
+  else if (hp < 2) [r, g, b] = [x, c, 0];
+  else if (hp < 3) [r, g, b] = [0, c, x];
+  else if (hp < 4) [r, g, b] = [0, x, c];
+  else if (hp < 5) [r, g, b] = [x, 0, c];
+  else [r, g, b] = [c, 0, x];
+  const m = lN - c / 2;
+  return [
+    Math.round((r + m) * 255),
+    Math.round((g + m) * 255),
+    Math.round((b + m) * 255),
+  ];
+}
+
+// Precomputed Uint32 (ABGR little-endian) LUT for canvas pixel writes.
+// Ages > 30 saturate to red.
+const COLOR_LUT_U32: Uint32Array = (() => {
+  const lut = new Uint32Array(31);
+  const pack = (r: number, g: number, b: number) => ((0xff << 24) | (b << 16) | (g << 8) | r) >>> 0;
+  lut[0] = pack(...DEAD_RGB);
+  for (let i = 1; i <= 30; i++) {
+    const { h, s, l } = hslAtAge(i);
+    const [r, g, b] = hslToRgb(h, s, l);
+    lut[i] = pack(r, g, b);
+  }
+  return lut;
+})();
+
+function ageColorU32(age: number): number {
+  return COLOR_LUT_U32[Math.min(age, 30)];
+}
+
+// ---------------------------------------------------------------
+// Cell — subscribes to one signal, re-renders only when its age changes.
+// ---------------------------------------------------------------
+
+let _cellRenders = 0;
+function bumpRender() { _cellRenders++; }
+function takeRenders() { const r = _cellRenders; _cellRenders = 0; return r; }
+
+const Cell = memo(function Cell({ sig, onPaint }: {
+  sig: RefSignal<number>;
+  onPaint: (sig: RefSignal<number>) => void;
+}) {
+  bumpRender();
+  const ref = useRef<HTMLDivElement>(null);
+  // Imperative: signal updates write style.background directly. React renders
+  // this component once at mount and (almost) never again.
+  useRefSignalEffect(() => {
+    const el = ref.current;
+    if (el) el.style.background = ageColor(sig.current);
+  }, [sig]);
+  return (
+    <div
+      ref={ref}
+      onPointerDown={() => onPaint(sig)}
+      onPointerEnter={(e) => { if (e.buttons === 1) onPaint(sig); }}
+      style={{ background: ageColor(sig.current) }}
+    />
+  );
+});
+
+// ---------------------------------------------------------------
+// CanvasGrid — same one-signal-per-cell model, single canvas observer.
+// Subscribes to every cell; on signal fire, marks pixel dirty + schedules rAF.
+// rAF flushes a single putImageData. ~100x faster than per-cell DOM writes.
+// ---------------------------------------------------------------
+
+function CanvasGrid({ grid, onPaint }: {
+  grid: RefSignal<number>[][];
+  onPaint: (sig: RefSignal<number>) => void;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const onPaintRef = useRef(onPaint);
+  onPaintRef.current = onPaint;
+  const { w, h } = dimsOf(grid);
+
+  // Per-cell listeners push the changed index into `dirty` and bump
+  // `dirtyBump`. The flush below subscribes to dirtyBump with `rAF: true`,
+  // which collapses N bumps within a frame into a single flush — the lib
+  // handles the rAF scheduling that used to be a manual rafId/cancel pair.
+  const dirty = useMemo(() => new Set<number>(), []);
+  const dirtyBump = useMemo(() => createRefSignal(0), []);
+  const paintRef = useRef<{
+    ctx: CanvasRenderingContext2D;
+    pixels: Uint32Array;
+    imgData: ImageData;
+  } | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    canvas.width = w;
+    canvas.height = h;
+    const ctx = canvas.getContext('2d', { alpha: false });
+    if (!ctx) return;
+
+    const imgData = ctx.createImageData(w, h);
+    const pixels = new Uint32Array(imgData.data.buffer);
+    paintRef.current = { ctx, pixels, imgData };
+    dirty.clear();
+
+    // Initial paint — fill all pixels and putImageData once.
+    for (let y = 0; y < h; y++) {
+      for (let x = 0; x < w; x++) {
+        pixels[y * w + x] = ageColorU32(grid[y][x].current);
+      }
+    }
+    ctx.putImageData(imgData, 0, 0);
+
+    // Subscribe per cell — listener pushes to dirty set + bumps the flush.
+    const unsubs: Array<() => void> = [];
+    for (let y = 0; y < h; y++) {
+      for (let x = 0; x < w; x++) {
+        const idx = y * w + x;
+        const sig = grid[y][x];
+        const listener = () => {
+          dirty.add(idx);
+          dirtyBump.notify();
+        };
+        sig.subscribe(listener);
+        unsubs.push(() => sig.unsubscribe(listener));
+      }
+    }
+
+    return () => {
+      paintRef.current = null;
+      for (const u of unsubs) u();
+    };
+  }, [grid, w, h, dirty, dirtyBump]);
+
+  useRefSignalEffect(
+    () => {
+      const p = paintRef.current;
+      if (!p || dirty.size === 0) return;
+      const { ctx, pixels, imgData } = p;
+      for (const idx of dirty) {
+        const y = (idx / w) | 0;
+        const x = idx - y * w;
+        pixels[idx] = ageColorU32(grid[y][x].current);
+      }
+      dirty.clear();
+      ctx.putImageData(imgData, 0, 0);
+    },
+    [dirtyBump, grid, w, h, dirty],
+    { rAF: true },
+  );
+
+  const handlePointer = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (e.type === 'pointermove' && e.buttons !== 1) return;
+    const canvas = e.currentTarget;
+    const rect = canvas.getBoundingClientRect();
+    const x = Math.floor(((e.clientX - rect.left) / rect.width) * w);
+    const y = Math.floor(((e.clientY - rect.top) / rect.height) * h);
+    if (x >= 0 && x < w && y >= 0 && y < h) {
+      onPaintRef.current(grid[y][x]);
+    }
+  };
+
+  return (
+    <canvas
+      ref={canvasRef}
+      onPointerDown={handlePointer}
+      onPointerMove={handlePointer}
+      style={{
+        imageRendering: 'pixelated',
+        width: '100%',
+        height: '100%',
+        display: 'block',
+        background: DEAD,
+        touchAction: 'none',
+        userSelect: 'none',
+      }}
+    />
+  );
+}
+
+// ---------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------
+
+type Mode = 'dom' | 'canvas';
+
+export default function GameOfLife() {
+  const [mode, setMode] = useState<Mode>('dom');
+  const [size, setSize] = useState<Size>(80); // DOM mode: square dim
+  const [cellPx, setCellPx] = useState<CellPx>(6); // Canvas mode: pixels per cell
+  const [running, setRunning] = useState(false);
+  const [speed, setSpeed] = useState(20); // ticks/sec target
+  const [tickN, setTickN] = useState(0);
+  const [stats, setStats] = useState({ alive: 0, changed: 0, rps: 0 });
+
+  // Stage container size for canvas mode (rectangular, fills available space).
+  // Initial fallback uses window dims; ResizeObserver corrects after mount.
+  const stageRef = useRef<HTMLDivElement>(null);
+  const [stageDims, setStageDims] = useState<{ w: number; h: number }>(() => ({
+    w: typeof window !== 'undefined' ? window.innerWidth - 32 : 1024,
+    h: typeof window !== 'undefined' ? window.innerHeight - 140 : 720,
+  }));
+
+  useEffect(() => {
+    const measure = () => {
+      const el = stageRef.current;
+      if (!el) return;
+      const r = el.getBoundingClientRect();
+      const w = Math.floor(r.width);
+      const h = Math.floor(r.height);
+      setStageDims((prev) => (prev.w === w && prev.h === h ? prev : { w, h }));
+    };
+    // Measure after first paint so layout has settled.
+    const rafId = requestAnimationFrame(measure);
+    // Only re-measure on viewport resize — NOT on internal toolbar reflows
+    // (which would fire constantly as stats text width changes).
+    window.addEventListener('resize', measure);
+    return () => {
+      cancelAnimationFrame(rafId);
+      window.removeEventListener('resize', measure);
+    };
+  }, []);
+
+  // Logical grid dimensions per mode.
+  const dims = useMemo(() => {
+    if (mode === 'dom') return { w: size, h: size };
+    return {
+      w: Math.max(16, Math.floor(stageDims.w / cellPx)),
+      h: Math.max(16, Math.floor(stageDims.h / cellPx)),
+    };
+  }, [mode, size, cellPx, stageDims]);
+
+  // Recreate grid on dims change.
+  const grid = useMemo(() => makeGrid(dims.w, dims.h), [dims.w, dims.h]);
+
+  // Seed with a pulsar (or glider if it doesn't fit).
+  useEffect(() => {
+    const initial =
+      patternFits(PATTERNS[1], dims.w, dims.h) ? PATTERNS[1] : PATTERNS[0];
+    placePattern(grid, initial);
+    setTickN(0);
+    setStats({ alive: 0, changed: 0, rps: 0 });
+  }, [grid, dims.w, dims.h]);
+
+  // Pulse-driven tick loop with target-tps gating. The pulse fires every
+  // animation frame at the display's native rate; we gate ticks by the
+  // selected `speed` (ticks/sec) using `frame.elapsed` as the clock.
+  const frame = usePulseRefSignal('raf');
+  const lastTickRef = useRef(0);
+  const sampleStartRef = useRef(0);
+  useEffect(() => {
+    if (!running) return;
+    lastTickRef.current = 0;
+    sampleStartRef.current = 0;
+    takeRenders();
+  }, [running, speed, grid]);
+  useRefSignalEffect(
+    () => {
+      if (!running) return;
+      const now = frame.elapsed;
+      const interval = 1000 / speed;
+      let alive = stats.alive;
+      let changed = stats.changed;
+      let didTick = false;
+      if (now - lastTickRef.current >= interval) {
+        const r = tick(grid);
+        alive = r.alive;
+        changed = r.changed;
+        lastTickRef.current = now;
+        didTick = true;
+      }
+      if (now - sampleStartRef.current >= 1000) {
+        const rps = takeRenders();
+        setStats({ alive, changed, rps });
+        sampleStartRef.current = now;
+      } else if (didTick) {
+        setStats((s) => ({ ...s, alive, changed }));
+      }
+      if (didTick) setTickN((n) => n + 1);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- stats setter is stable; timing state held in refs
+    [frame, running, speed, grid],
+  );
+
+  const onPaint = useCallback((sig: RefSignal<number>) => {
+    if (running) return; // only paint when paused
+    sig.update(sig.current > 0 ? 0 : 1);
+  }, [running]);
+
+  const stepOnce = useCallback(() => {
+    const { alive, changed } = tick(grid);
+    setTickN((n) => n + 1);
+    setStats((s) => ({ ...s, alive, changed }));
+  }, [grid]);
+
+  const total = dims.w * dims.h;
+  const changedPct = total > 0 ? ((stats.changed / total) * 100).toFixed(1) : '0';
+
+  return (
+    <div style={pageStyle}>
+      <div style={toolbarStyle}>
+        {PATTERNS.map((p) => {
+          const ok = patternFits(p, dims.w, dims.h);
+          return (
+            <button
+              key={p.name}
+              disabled={!ok}
+              onClick={() => placePattern(grid, p)}
+              style={btnStyle(false, '#4a9eff', !ok)}
+              title={ok ? '' : `Doesn't fit ${dims.w}×${dims.h}`}
+            >
+              {p.name}
+            </button>
+          );
+        })}
+        <button
+          onClick={() => clearGrid(grid)}
+          style={btnStyle(false, '#64748b')}
+        >
+          Clear
+        </button>
+
+        <span style={sep} />
+
+        <button
+          onClick={() => setRunning((r) => !r)}
+          style={btnStyle(running, running ? '#f97316' : '#10b981')}
+        >
+          {running ? 'Pause' : 'Play'}
+        </button>
+        <button
+          disabled={running}
+          onClick={stepOnce}
+          style={btnStyle(false, '#4a9eff', running)}
+        >
+          Step
+        </button>
+
+        <label style={sliderLabel}>
+          Speed
+          <input
+            type="range"
+            min={1}
+            max={60}
+            value={speed}
+            onChange={(e) => setSpeed(+e.target.value)}
+          />
+          <span style={tinyMono}>{speed}/s</span>
+        </label>
+
+        <span style={sep} />
+
+        <span style={{ display: 'flex', gap: 0, borderRadius: 6, overflow: 'hidden' }}>
+          <button
+            onClick={() => setMode('dom')}
+            style={{ ...btnStyle(mode === 'dom', '#4a9eff'), borderRadius: 0 }}
+          >
+            DOM
+          </button>
+          <button
+            onClick={() => setMode('canvas')}
+            style={{ ...btnStyle(mode === 'canvas', '#a855f7'), borderRadius: 0 }}
+          >
+            Canvas
+          </button>
+        </span>
+
+        {mode === 'dom' ? (
+          <label style={sliderLabel}>
+            Size
+            <select
+              value={size}
+              onChange={(e) => setSize(+e.target.value as Size)}
+              style={selectStyle}
+            >
+              {SIZES.map((s) => (
+                <option key={s} value={s}>
+                  {s}×{s}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : (
+          <label style={sliderLabel}>
+            Cell px
+            <select
+              value={cellPx}
+              onChange={(e) => setCellPx(+e.target.value as CellPx)}
+              style={selectStyle}
+            >
+              {CELL_PX.map((p) => (
+                <option key={p} value={p}>
+                  {p}px
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+
+        <span style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
+          <Stat label="grid" value={`${dims.w}×${dims.h}`} />
+          <Stat label="tick" value={tickN} />
+          <Stat label="alive" value={`${stats.alive}/${total}`} />
+          <Stat label="changed/tick" value={`${stats.changed} (${changedPct}%)`} highlight />
+          <Stat label="renders/s" value={stats.rps || '--'} />
+          <FpsBadge />
+        </span>
+      </div>
+
+      <div style={hintStyle}>
+        Both modes: zero React renders post-mount (<b>renders/s</b> ≈ 0). The signal listener
+        does the work directly.
+        {' '}
+        {mode === 'dom' ? (
+          <>
+            <b>DOM</b>: <code style={codeStyle}>useRefSignalEffect</code> writes{' '}
+            <code style={codeStyle}>style.background</code> on each changed cell — browser does N
+            independent style recalcs + paints per tick. Bottleneck at 100×100 + Random.
+          </>
+        ) : (
+          <>
+            <b>Canvas</b>: rectangular grid auto-fitted to the viewport ({dims.w}×{dims.h} ={' '}
+            {total.toLocaleString()} signals). Each cell&apos;s listener marks a pixel dirty +
+            schedules rAF; one <code style={codeStyle}>putImageData</code> per frame. Try Random +
+            60/s — should hit your monitor&apos;s refresh rate.
+          </>
+        )}
+        {' '}Click/drag (paused) to paint.
+      </div>
+
+      <div ref={stageRef} style={{ flex: 1, overflow: 'hidden', padding: 8 }}>
+        {mode === 'dom' ? (
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: `repeat(${dims.w}, 1fr)`,
+              gridTemplateRows: `repeat(${dims.h}, 1fr)`,
+              gap: 1,
+              background: '#1e293b',
+              width: '100%',
+              height: '100%',
+              aspectRatio: '1 / 1',
+              margin: '0 auto',
+              maxHeight: '100%',
+              maxWidth: 'min(100%, calc(100vh - 140px))',
+              touchAction: 'none',
+              userSelect: 'none',
+            }}
+            onPointerLeave={(e) => e.currentTarget.releasePointerCapture?.(e.pointerId)}
+          >
+            {grid.map((row, y) =>
+              row.map((sig, x) => <Cell key={`${y}-${x}`} sig={sig} onPaint={onPaint} />),
+            )}
+          </div>
+        ) : (
+          <CanvasGrid grid={grid} onPaint={onPaint} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------
+// UI bits
+// ---------------------------------------------------------------
+
+function Stat({ label, value, highlight }: { label: string; value: string | number; highlight?: boolean }) {
+  return (
+    <span style={{
+      background: '#0d1117',
+      padding: '4px 10px',
+      borderRadius: 4,
+      fontSize: 12,
+      fontFamily: 'monospace',
+      border: highlight ? '1px solid #4a9eff' : '1px solid transparent',
+    }}>
+      {label} <b style={{ color: highlight ? '#4a9eff' : '#fff' }}>{value}</b>
+    </span>
+  );
+}
+
+const pageStyle: React.CSSProperties = {
+  background: '#1a1a2e',
+  color: '#fff',
+  height: '100vh',
+  display: 'flex',
+  flexDirection: 'column',
+  fontFamily: 'system-ui, sans-serif',
+  userSelect: 'none',
+};
+
+const toolbarStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '8px 14px',
+  background: '#16213e',
+  flexWrap: 'wrap',
+};
+
+const hintStyle: React.CSSProperties = {
+  padding: '3px 14px',
+  fontSize: 11,
+  opacity: 0.55,
+  background: '#16213e',
+  borderTop: '1px solid #1a1a2e',
+};
+
+const sliderLabel: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 6,
+  fontSize: 12,
+  opacity: 0.85,
+};
+
+const selectStyle: React.CSSProperties = {
+  background: '#0d1117',
+  color: '#fff',
+  border: '1px solid #334155',
+  borderRadius: 4,
+  padding: '3px 6px',
+  fontSize: 12,
+};
+
+const tinyMono: React.CSSProperties = { fontFamily: 'monospace', fontSize: 11, opacity: 0.7, minWidth: 32 };
+
+const sep: React.CSSProperties = { width: 1, height: 20, background: '#334155' };
+
+const codeStyle: React.CSSProperties = {
+  padding: '1px 6px',
+  borderRadius: 3,
+  fontFamily: 'monospace',
+  fontSize: 11,
+  background: 'rgba(255,255,255,0.1)',
+};
+
+function btnStyle(active: boolean, color: string, disabled = false): React.CSSProperties {
+  return {
+    padding: '5px 12px',
+    border: 'none',
+    borderRadius: 6,
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    fontWeight: 600,
+    fontSize: 12,
+    background: active ? color : '#333',
+    color: '#fff',
+    opacity: disabled ? 0.3 : active ? 1 : 0.75,
+    transition: 'opacity 0.15s',
+  };
+}

--- a/demo/main.tsx
+++ b/demo/main.tsx
@@ -2,13 +2,18 @@ import { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import GraphBenchmark from './graph-benchmark';
 import ThemeDemo from './theme-demo';
+import GameOfLife from './game-of-life';
+import Agents from './agents';
 
 // StrictMode removed for clean benchmark numbers (it double-renders in dev).
 
-type Route = 'graph' | 'theme';
+type Route = 'graph' | 'theme' | 'gol' | 'agents';
 
 function parseRoute(): Route {
-  return window.location.hash === '#theme' ? 'theme' : 'graph';
+  if (window.location.hash === '#theme') return 'theme';
+  if (window.location.hash === '#gol') return 'gol';
+  if (window.location.hash === '#agents') return 'agents';
+  return 'graph';
 }
 
 function Demos() {
@@ -49,8 +54,17 @@ function Demos() {
         <a href="#theme" style={navBtn(route === 'theme')}>
           Theme sync (persist + broadcast)
         </a>
+        <a href="#gol" style={navBtn(route === 'gol')}>
+          Game of Life
+        </a>
+        <a href="#agents" style={navBtn(route === 'agents')}>
+          Agents
+        </a>
       </nav>
-      {route === 'graph' ? <GraphBenchmark /> : <ThemeDemo />}
+      {route === 'graph' && <GraphBenchmark />}
+      {route === 'theme' && <ThemeDemo />}
+      {route === 'gol' && <GameOfLife />}
+      {route === 'agents' && <Agents />}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Rewrite README around the per-consumer subscription thesis (what / when / whether, per call site)
- Simplify the GameCanvas Quick Start example using `usePulseRefSignal('raf')` — drops the manual rAF setup
- Add three new demos (`agents`, `fps`, `game-of-life`), wired into `demo/main.tsx`

## Test plan
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `npm test` (524/524)
- [x] `cd demo && vite build` clean

## Notes
Based on top of `feat/pulse-raf` (#9). Will retarget to `main` automatically once that lands.