### PR TITLE
demo: heartbeat + cleanup

### DIFF
--- a/demo/agents.tsx
+++ b/demo/agents.tsx
@@ -1,25 +1,8 @@
-// demo/agents.tsx
-//
-// Automated agar.io-style chase/flee simulation. Permadeath — last one standing
-// wins. The actual signal demo:
-//
-//   - Each agent owns position / size / alive / callTarget signals.
-//   - SVG circles update via per-signal `useRefSignalEffect` — no React renders
-//     in the per-frame path.
-//   - Six independent reactive consumers each subscribe to ONLY the signals they
-//     care about: alive count, biggest badge, calls count, leaderboard, team
-//     scoreboard, killcam feed, winner banner. None of them re-render on
-//     simulation ticks unless their slice of state actually changed.
-//   - Inter-agent coordination via signals: each agent broadcasts its current
-//     target via `callTarget`. Same-team allies within HEARING radius adopt
-//     the call when they lack a target of their own — pack-hunting emerges.
-//     The CallLines layer follows each call with `trackSignals` so when an
-//     agent's callTarget changes, the line subscription swaps to the new
-//     target's position signal automatically.
-//
-// This is what signals are actually for: heterogeneous fanout of changes to
-// different consumers without a central re-render or manual invalidation,
-// plus declarative cross-entity communication without a central event bus.
+// Agar.io-style chase/flee simulation, permadeath. Each agent owns
+// position/size/alive/callTarget signals; per-signal effects update the SVG
+// directly — no per-frame React renders. Reactive panels each subscribe only
+// to their slice. Same-team call broadcasts via `callTarget` propagate through
+// `trackSignals` for emergent pack-hunting.
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
@@ -49,13 +32,10 @@ type Agent = {
   vx: number;
   vy: number;
   kills: number;
-  // Tracked across ticks to avoid flip-flop between equidistant candidates —
-  // each agent sticks with its current target/threat as long as it remains valid.
+  // Sticky picks across ticks — avoids flip-flop between equidistant candidates.
   targetId: number | null;
   threatId: number | null;
-  // Public broadcast of "the target I've committed to." Same-team allies within
-  // HEARING radius can adopt this when they have no target of their own. Pack
-  // hunting emerges as the call propagates outward each tick.
+  // Broadcast for same-team call adoption (HEARING radius).
   callTarget: RefSignal<number | null>;
 };
 
@@ -99,22 +79,46 @@ const GRID_CELL = 80; // spatial-hash cell size — tuned so VISION (220) covers
 const TURN_RATE = 0.15; // steering inertia (0 = no turn, 1 = instant turn)
 
 const ADJ = [
-  'Swift', 'Brave', 'Sneaky', 'Wild', 'Clever', 'Bold', 'Sly', 'Fierce',
-  'Cosmic', 'Thunder', 'Iron', 'Storm', 'Shadow', 'Crystal', 'Nimble',
+  'Swift',
+  'Brave',
+  'Sneaky',
+  'Wild',
+  'Clever',
+  'Bold',
+  'Sly',
+  'Fierce',
+  'Cosmic',
+  'Thunder',
+  'Iron',
+  'Storm',
+  'Shadow',
+  'Crystal',
+  'Nimble',
 ];
 const NOUN = [
-  'Fox', 'Wolf', 'Hawk', 'Bear', 'Tiger', 'Owl', 'Cobra', 'Falcon',
-  'Lynx', 'Raven', 'Lion', 'Shark', 'Eagle', 'Panther', 'Drake',
+  'Fox',
+  'Wolf',
+  'Hawk',
+  'Bear',
+  'Tiger',
+  'Owl',
+  'Cobra',
+  'Falcon',
+  'Lynx',
+  'Raven',
+  'Lion',
+  'Shark',
+  'Eagle',
+  'Panther',
+  'Drake',
 ];
 
-// Killcam feed — one RefSignal holding the last N kills. Subscribed by the
-// Killcam component and (transitively) the leaderboard's "kills" stat.
+// Last N kills — feeds the Killcam component.
 const killFeed = createRefSignal<KillEvent[]>([]);
 
-// Module-scope simulation speed (ticks/sec target). The slider component
-// subscribes via useRefSignalRender; the RAF loop reads `.current` directly
-// without re-subscribing — changing speed never restarts the loop.
-const tickSpeed = createRefSignal<number>(60);
+// Module-scope ticks/sec target. RAF loop reads `.current` directly so speed
+// changes don't restart the subscription.
+const tickSpeed = createRefSignal(60);
 
 function pushKill(ev: KillEvent) {
   killFeed.update([ev, ...killFeed.current].slice(0, KILLCAM_MAX));
@@ -136,9 +140,79 @@ function pick<T>(arr: readonly T[]): T {
   return arr[Math.floor(Math.random() * arr.length)];
 }
 
+function distSq(a: Vec, b: Vec): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return dx * dx + dy * dy;
+}
+
+// X dominates Y when X exceeds Y's mass by the size threshold (eat / flee gate).
+function dominates(predator: number, prey: number): boolean {
+  return predator > prey * SIZE_THRESHOLD;
+}
+
+// Apply steering inertia, clamp to world bounds, write the new position.
+// Shared by player control and AI control — same physics either way.
+function steerAndMove(
+  a: Agent,
+  ap: Vec,
+  ddx: number,
+  ddy: number,
+  speed: number,
+  world: Vec,
+): void {
+  const dlen = Math.hypot(ddx, ddy) || 1;
+  const desVx = (ddx / dlen) * speed;
+  const desVy = (ddy / dlen) * speed;
+  const sVx = a.vx * (1 - TURN_RATE) + desVx * TURN_RATE;
+  const sVy = a.vy * (1 - TURN_RATE) + desVy * TURN_RATE;
+  const sLen = Math.hypot(sVx, sVy) || 1;
+  a.vx = (sVx / sLen) * speed;
+  a.vy = (sVy / sLen) * speed;
+  let nx = ap.x + a.vx;
+  let ny = ap.y + a.vy;
+  if (nx < 0) {
+    nx = 0;
+    a.vx = Math.abs(a.vx);
+  } else if (nx > world.x) {
+    nx = world.x;
+    a.vx = -Math.abs(a.vx);
+  }
+  if (ny < 0) {
+    ny = 0;
+    a.vy = Math.abs(a.vy);
+  } else if (ny > world.y) {
+    ny = world.y;
+    a.vy = -Math.abs(a.vy);
+  }
+  a.position.update({ x: nx, y: ny });
+}
+
+// Pairwise eat-test over two buckets. `sameBucket` short-circuits the i/j
+// pairing so we don't double-test pairs from the same cell.
+function eatPairs(
+  bucketA: Agent[],
+  bucketB: Agent[],
+  sameBucket: boolean,
+): void {
+  for (let i = 0; i < bucketA.length; i++) {
+    const a = bucketA[i];
+    if (!a.alive.current) continue;
+    const jStart = sameBucket ? i + 1 : 0;
+    for (let j = jStart; j < bucketB.length; j++) {
+      const b = bucketB[j];
+      if (!b.alive.current) continue;
+      tryEat(a, b);
+      // tryEat may flip a.alive
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (!a.alive.current) break;
+    }
+  }
+}
+
 function makeAgent(id: number, world: Vec): Agent {
   const team = id % N_TEAMS;
-  const baseHue = TEAM_HUES[team];
+  const baseHue = TEAM_HUES[team]!;
   // Slight per-agent jitter within team color band.
   const hue = (baseHue + rand(-12, 12) + 360) % 360;
   return {
@@ -146,7 +220,7 @@ function makeAgent(id: number, world: Vec): Agent {
     team,
     hue,
     name: `${pick(ADJ)}${pick(NOUN)}`,
-    position: createRefSignal<Vec>({
+    position: createRefSignal({
       x: rand(40, world.x - 40),
       y: rand(40, world.y - 40),
     }),
@@ -182,30 +256,31 @@ function tryEat(a: Agent, b: Agent) {
   const bp = b.position.current;
   const aSize = a.size.current;
   const bSize = b.size.current;
-  const ar = radiusOf(aSize);
-  const br = radiusOf(bSize);
-  const dx = ap.x - bp.x;
-  const dy = ap.y - bp.y;
-  const d2 = dx * dx + dy * dy;
-  const eatD = Math.max(ar, br) * 0.6;
-  if (d2 >= eatD * eatD) return;
-  if (aSize > bSize * SIZE_THRESHOLD) {
+  const eatD = Math.max(radiusOf(aSize), radiusOf(bSize)) * 0.6;
+  if (distSq(ap, bp) >= eatD * eatD) return;
+  if (dominates(aSize, bSize)) {
     a.size.update(aSize + bSize * MASS_GAIN);
     b.alive.update(false);
     b.callTarget.update(null);
     a.kills++;
     pushKill({
-      killerId: a.id, killerName: a.name, killerHue: a.hue,
-      victimName: b.name, victimHue: b.hue,
+      killerId: a.id,
+      killerName: a.name,
+      killerHue: a.hue,
+      victimName: b.name,
+      victimHue: b.hue,
     });
-  } else if (bSize > aSize * SIZE_THRESHOLD) {
+  } else if (dominates(bSize, aSize)) {
     b.size.update(bSize + aSize * MASS_GAIN);
     a.alive.update(false);
     a.callTarget.update(null);
     b.kills++;
     pushKill({
-      killerId: b.id, killerName: b.name, killerHue: b.hue,
-      victimName: a.name, victimHue: a.hue,
+      killerId: b.id,
+      killerName: b.name,
+      killerHue: b.hue,
+      victimName: a.name,
+      victimHue: a.hue,
     });
   }
 }
@@ -216,20 +291,24 @@ function tick(
   world: Vec,
   control: ControlState,
 ): TickResult {
-  // ─── Spatial hash: bucket alive agents + pellets into a coarse grid. ───
-  // AI and collision queries become O(local density) instead of O(N).
+  // Spatial hash → AI and collision queries are O(local density), not O(N).
   const cw = ((world.x / GRID_CELL) | 0) + 2;
   const ch = ((world.y / GRID_CELL) | 0) + 2;
   const total = cw * ch;
   const aGrid: Agent[][] = new Array(total);
   const pGrid: Pellet[][] = new Array(total);
-  for (let i = 0; i < total; i++) { aGrid[i] = []; pGrid[i] = []; }
+  for (let i = 0; i < total; i++) {
+    aGrid[i] = [];
+    pGrid[i] = [];
+  }
 
   const cellAt = (x: number, y: number) => {
     let cx = (x / GRID_CELL) | 0;
     let cy = (y / GRID_CELL) | 0;
-    if (cx < 0) cx = 0; else if (cx >= cw) cx = cw - 1;
-    if (cy < 0) cy = 0; else if (cy >= ch) cy = ch - 1;
+    if (cx < 0) cx = 0;
+    else if (cx >= cw) cx = cw - 1;
+    if (cy < 0) cy = 0;
+    else if (cy >= ch) cy = ch - 1;
     return cy * cw + cx;
   };
 
@@ -262,60 +341,47 @@ function tick(
       const aSize = a.size.current;
       const speed = BASE_SPEED / Math.sqrt(Math.max(1, aSize / 5));
 
-      // ── Player control: bypass AI entirely. ──────────────────────────
-      // Controlled agent steers toward the mouse cursor. No automatic
-      // threat avoidance — getting eaten is the player's responsibility.
+      // Player control: steer toward cursor, bypass AI (no auto threat avoidance).
       if (control.agentId === a.id) {
         a.targetId = null;
         a.threatId = null;
         a.callTarget.update(null);
-        const ddx = control.mouse.x - ap.x;
-        const ddy = control.mouse.y - ap.y;
-        const dlen = Math.hypot(ddx, ddy) || 1;
-        const desVx = (ddx / dlen) * speed;
-        const desVy = (ddy / dlen) * speed;
-        const sVx = a.vx * (1 - TURN_RATE) + desVx * TURN_RATE;
-        const sVy = a.vy * (1 - TURN_RATE) + desVy * TURN_RATE;
-        const sLen = Math.hypot(sVx, sVy) || 1;
-        a.vx = (sVx / sLen) * speed;
-        a.vy = (sVy / sLen) * speed;
-        let nx = ap.x + a.vx;
-        let ny = ap.y + a.vy;
-        if (nx < 0) { nx = 0; a.vx = Math.abs(a.vx); }
-        else if (nx > world.x) { nx = world.x; a.vx = -Math.abs(a.vx); }
-        if (ny < 0) { ny = 0; a.vy = Math.abs(a.vy); }
-        else if (ny > world.y) { ny = world.y; a.vy = -Math.abs(a.vy); }
-        a.position.update({ x: nx, y: ny });
+        steerAndMove(
+          a,
+          ap,
+          control.mouse.x - ap.x,
+          control.mouse.y - ap.y,
+          speed,
+          world,
+        );
         continue;
       }
 
       const acx = (ap.x / GRID_CELL) | 0;
       const acy = (ap.y / GRID_CELL) | 0;
 
-      // ── Persistence: keep last tick's target/threat if still valid. ──
-      // This is the main fix for "bouncing": instead of re-picking from
-      // scratch each tick (which flip-flops between equidistant candidates),
-      // we stick with the current pick until it dies, leaves vision, or
-      // ceases to satisfy the size threshold.
+      // Keep last tick's pick if still valid — avoids flip-flop between equidistant candidates.
       let target: Agent | null = null;
       let threat: Agent | null = null;
 
       if (a.targetId !== null) {
         const c = agents[a.targetId];
-        if (c && c.alive.current && aSize > c.size.current * SIZE_THRESHOLD) {
-          const cp = c.position.current;
-          const cdx = cp.x - ap.x;
-          const cdy = cp.y - ap.y;
-          if (cdx * cdx + cdy * cdy <= visionD2) target = c;
+        if (
+          c?.alive.current &&
+          dominates(aSize, c.size.current) &&
+          distSq(c.position.current, ap) <= visionD2
+        ) {
+          target = c;
         }
       }
       if (a.threatId !== null) {
         const c = agents[a.threatId];
-        if (c && c.alive.current && c.size.current > aSize * SIZE_THRESHOLD) {
-          const cp = c.position.current;
-          const cdx = cp.x - ap.x;
-          const cdy = cp.y - ap.y;
-          if (cdx * cdx + cdy * cdy <= visionD2) threat = c;
+        if (
+          c?.alive.current &&
+          dominates(c.size.current, aSize) &&
+          distSq(c.position.current, ap) <= visionD2
+        ) {
+          threat = c;
         }
       }
 
@@ -333,25 +399,26 @@ function tick(
             for (let bi = 0; bi < bucket.length; bi++) {
               const b = bucket[bi];
               if (b === a) continue;
-              const bp = b.position.current;
-              const dxx = bp.x - ap.x;
-              const dyy = bp.y - ap.y;
-              const d2 = dxx * dxx + dyy * dyy;
+              const d2 = distSq(b.position.current, ap);
               if (d2 > visionD2) continue;
               const bSize = b.size.current;
-              if (!target && aSize > bSize * SIZE_THRESHOLD) {
-                if (d2 < bestTargetD2) { target = b; bestTargetD2 = d2; }
-              } else if (!threat && bSize > aSize * SIZE_THRESHOLD) {
-                if (d2 < bestThreatD2) { threat = b; bestThreatD2 = d2; }
+              if (!target && dominates(aSize, bSize)) {
+                if (d2 < bestTargetD2) {
+                  target = b;
+                  bestTargetD2 = d2;
+                }
+              } else if (!threat && dominates(bSize, aSize)) {
+                if (d2 < bestThreatD2) {
+                  threat = b;
+                  bestThreatD2 = d2;
+                }
               }
             }
           }
         }
       }
-      // Same-team call adoption — listen for nearby allies broadcasting a target.
-      // If we have no target of our own and no threat, adopt the closest hearable
-      // ally's call (prey must still pass our own size threshold). Calls then
-      // propagate as we re-broadcast below — pack-hunting emerges across the team.
+      // Adopt nearest hearable ally's call when idle. Pack-hunting emerges as
+      // calls propagate via the re-broadcast below.
       if (!target && !threat) {
         const xLo = Math.max(0, acx - hearingRad);
         const xHi = Math.min(cw - 1, acx + hearingRad);
@@ -364,16 +431,13 @@ function tick(
             for (let bi = 0; bi < bucket.length; bi++) {
               const ally = bucket[bi];
               if (ally === a || ally.team !== a.team) continue;
-              const aap = ally.position.current;
-              const ddx = aap.x - ap.x;
-              const ddy = aap.y - ap.y;
-              const d2 = ddx * ddx + ddy * ddy;
+              const d2 = distSq(ally.position.current, ap);
               if (d2 > hearingD2 || d2 >= bestD2) continue;
               const calledId = ally.callTarget.current;
               if (calledId === null) continue;
               const called = agents[calledId];
-              if (!called || !called.alive.current) continue;
-              if (aSize <= called.size.current * SIZE_THRESHOLD) continue;
+              if (!called?.alive.current) continue;
+              if (!dominates(aSize, called.size.current)) continue;
               target = called;
               bestD2 = d2;
             }
@@ -383,9 +447,7 @@ function tick(
 
       a.targetId = target ? target.id : null;
       a.threatId = threat ? threat.id : null;
-      // Broadcast the target only when actively hunting — never while fleeing
-      // (would propagate panic) and never when there's no target. `update()` is
-      // a no-op when the value is unchanged, so this is cheap each tick.
+      // Only broadcast while hunting — fleeing would propagate panic.
       a.callTarget.update(!threat && target ? target.id : null);
 
       // Pellet seek when no agent priority.
@@ -401,11 +463,12 @@ function tick(
             const bucket = pGrid[cy * cw + cx];
             for (let bi = 0; bi < bucket.length; bi++) {
               const p = bucket[bi];
-              const dxx = p.x - ap.x;
-              const dyy = p.y - ap.y;
-              const d2 = dxx * dxx + dyy * dyy;
+              const d2 = distSq(p, ap);
               if (d2 > visionD2) continue;
-              if (d2 < pelletD2) { pelletT = p; pelletD2 = d2; }
+              if (d2 < pelletD2) {
+                pelletT = p;
+                pelletD2 = d2;
+              }
             }
           }
         }
@@ -430,60 +493,27 @@ function tick(
         ddy = a.vy + rand(-0.4, 0.4);
       }
 
-      const dlen = Math.hypot(ddx, ddy) || 1;
-      const desVx = (ddx / dlen) * speed;
-      const desVy = (ddy / dlen) * speed;
-
-      // Steering inertia: blend toward desired velocity. Smooths out
-      // direction flips and removes the "bouncing" feel for agents
-      // hesitating between candidates.
-      const sVx = a.vx * (1 - TURN_RATE) + desVx * TURN_RATE;
-      const sVy = a.vy * (1 - TURN_RATE) + desVy * TURN_RATE;
-      const sLen = Math.hypot(sVx, sVy) || 1;
-      a.vx = (sVx / sLen) * speed;
-      a.vy = (sVy / sLen) * speed;
-
-      let nx = ap.x + a.vx;
-      let ny = ap.y + a.vy;
-      if (nx < 0) { nx = 0; a.vx = Math.abs(a.vx); }
-      else if (nx > world.x) { nx = world.x; a.vx = -Math.abs(a.vx); }
-      if (ny < 0) { ny = 0; a.vy = Math.abs(a.vy); }
-      else if (ny > world.y) { ny = world.y; a.vy = -Math.abs(a.vy); }
-      a.position.update({ x: nx, y: ny });
+      steerAndMove(a, ap, ddx, ddy, speed, world);
     }
 
     // ─── 2. Agent-agent collisions via grid. ──────────────────────────
     // For each cell: pairs within + pairs with 4 "later" neighbor cells.
+    // 4 neighbors (E, SW, S, SE) covers each cross-cell pair exactly once.
+    const neigh: [number, number][] = [
+      [1, 0],
+      [-1, 1],
+      [0, 1],
+      [1, 1],
+    ];
     for (let cy = 0; cy < ch; cy++) {
       for (let cx = 0; cx < cw; cx++) {
         const bucket = aGrid[cy * cw + cx];
-        for (let i = 0; i < bucket.length; i++) {
-          const a = bucket[i];
-          if (!a.alive.current) continue;
-          for (let j = i + 1; j < bucket.length; j++) {
-            const b = bucket[j];
-            if (!b.alive.current) continue;
-            tryEat(a, b);
-            if (!a.alive.current) break;
-          }
-        }
-        // 4 neighbors: E, SW, S, SE — covers each pair exactly once.
-        const neigh: [number, number][] = [[1, 0], [-1, 1], [0, 1], [1, 1]];
+        eatPairs(bucket, bucket, true);
         for (let n = 0; n < neigh.length; n++) {
           const ncx = cx + neigh[n][0];
           const ncy = cy + neigh[n][1];
           if (ncx < 0 || ncx >= cw || ncy < 0 || ncy >= ch) continue;
-          const nbucket = aGrid[ncy * cw + ncx];
-          for (let i = 0; i < bucket.length; i++) {
-            const a = bucket[i];
-            if (!a.alive.current) continue;
-            for (let j = 0; j < nbucket.length; j++) {
-              const b = nbucket[j];
-              if (!b.alive.current) continue;
-              tryEat(a, b);
-              if (!a.alive.current) break;
-            }
-          }
+          eatPairs(bucket, aGrid[ncy * cw + ncx], false);
         }
       }
     }
@@ -506,9 +536,7 @@ function tick(
           for (let bi = 0; bi < bucket.length; bi++) {
             const p = bucket[bi];
             if (!p.alive.current) continue;
-            const dxx = ap.x - p.x;
-            const dyy = ap.y - p.y;
-            if (dxx * dxx + dyy * dyy < ar2) {
+            if (distSq(ap, p) < ar2) {
               a.size.update(a.size.current + PELLET_VALUE);
               p.alive.update(false);
               p.deadTicks = 0;
@@ -531,14 +559,23 @@ function tick(
     }
   });
 
-  return { gameOver: aliveCount <= 1, survivor: aliveCount === 1 ? last : null };
+  return {
+    gameOver: aliveCount <= 1,
+    survivor: aliveCount === 1 ? last : null,
+  };
 }
 
 // ---------------------------------------------------------------
 // AgentDot — vision ring + body + name. Three per-signal effects.
 // ---------------------------------------------------------------
 
-function AgentDot({ agent, showName, showVision, controlled, onTakeControl }: {
+function AgentDot({
+  agent,
+  showName,
+  showVision,
+  controlled,
+  onTakeControl,
+}: {
   agent: Agent;
   showName: boolean;
   showVision: boolean;
@@ -558,7 +595,10 @@ function AgentDot({ agent, showName, showVision, controlled, onTakeControl }: {
     const g = gRef.current;
     if (!g) return;
     const p = agent.position.current;
-    g.setAttribute('transform', `translate(${p.x.toFixed(1)},${p.y.toFixed(1)})`);
+    g.setAttribute(
+      'transform',
+      `translate(${p.x.toFixed(1)},${p.y.toFixed(1)})`,
+    );
   }, [agent.position]);
 
   useRefSignalEffect(() => {
@@ -704,8 +744,7 @@ function CallLine({ agent, agents }: { agent: Agent; agents: Agent[] }) {
     },
     [agent.callTarget, agent.position, agent.alive],
     {
-      // Dynamic dep — when callTarget swaps, the subscription follows the new
-      // target's position/alive without needing to tear down + recreate the effect.
+      // Dynamic dep — re-subscribes to the new target's signals when callTarget swaps.
       trackSignals: () => {
         const id = agent.callTarget.current;
         if (id === null) return [];
@@ -754,12 +793,12 @@ function BiggestBadge({ agents }: { agents: Agent[] }) {
 }
 
 function CallsCount({ agents }: { agents: Agent[] }) {
-  // Subscribes only to the callTarget slice — re-renders when agents start
-  // or stop broadcasting, never on plain position updates.
+  // callTarget slice only — never re-renders on plain position updates.
   const sigs = useMemo(() => agents.map((a) => a.callTarget), [agents]);
   useRefSignalRender(sigs, { rAF: true });
   let n = 0;
-  for (const a of agents) if (a.alive.current && a.callTarget.current !== null) n++;
+  for (const a of agents)
+    if (a.alive.current && a.callTarget.current !== null) n++;
   return <Stat label="calls" value={n} />;
 }
 
@@ -782,7 +821,17 @@ function Leaderboard({ agents }: { agents: Agent[] }) {
         <div key={a.id} style={leaderRow}>
           <span style={rankCell}>#{i + 1}</span>
           <Dot hue={a.hue} />
-          <span style={{ fontSize: 11, opacity: 0.85, flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          <span
+            style={{
+              fontSize: 11,
+              opacity: 0.85,
+              flex: 1,
+              minWidth: 0,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
             {a.name}
           </span>
           <span style={{ fontFamily: 'monospace', fontSize: 11 }}>
@@ -814,8 +863,7 @@ function TeamRow({ team, agents }: { team: number; agents: Agent[] }) {
     () => teamAgents.flatMap((a) => [a.size, a.alive]),
     [teamAgents],
   );
-  // KEY POINT: this row only re-renders when its own team's signals fire.
-  // Other teams' changes don't trigger anything here.
+  // Re-renders only on its own team's signals — other teams don't trigger anything here.
   useRefSignalRender(sigs, { rAF: true });
 
   let alive = 0;
@@ -848,10 +896,26 @@ function TeamRow({ team, agents }: { team: number; agents: Agent[] }) {
         }}
       />
       <span style={{ fontSize: 11, flex: 1 }}>{TEAM_NAMES[team]}</span>
-      <span style={{ fontFamily: 'monospace', fontSize: 11, opacity: 0.7, minWidth: 30, textAlign: 'right' }}>
+      <span
+        style={{
+          fontFamily: 'monospace',
+          fontSize: 11,
+          opacity: 0.7,
+          minWidth: 30,
+          textAlign: 'right',
+        }}
+      >
         {alive}/{teamAgents.length}
       </span>
-      <span style={{ fontFamily: 'monospace', fontSize: 11, color: '#4a9eff', minWidth: 36, textAlign: 'right' }}>
+      <span
+        style={{
+          fontFamily: 'monospace',
+          fontSize: 11,
+          color: '#4a9eff',
+          minWidth: 36,
+          textAlign: 'right',
+        }}
+      >
         {mass.toFixed(0)}
       </span>
     </div>
@@ -859,7 +923,6 @@ function TeamRow({ team, agents }: { team: number; agents: Agent[] }) {
 }
 
 function Killcam() {
-  // Subscribes only to the killFeed signal — re-renders only on kills.
   useRefSignalRender([killFeed]);
   const events = killFeed.current;
 
@@ -885,14 +948,29 @@ function Killcam() {
   );
 }
 
-function WinnerBanner({ winner, onReset }: { winner: Agent; onReset: () => void }) {
-  // Subscribe to the winner's size in case mass keeps creeping from pellets.
+function WinnerBanner({
+  winner,
+  onReset,
+}: {
+  winner: Agent;
+  onReset: () => void;
+}) {
+  // Track winner's size — pellets keep adding mass post-victory.
   useRefSignalRender([winner.size]);
   return (
     <div style={winnerOverlayStyle}>
       <div style={winnerCardStyle}>
-        <div style={{ fontSize: 12, opacity: 0.55, letterSpacing: 1 }}>WINNER</div>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginTop: 8 }}>
+        <div style={{ fontSize: 12, opacity: 0.55, letterSpacing: 1 }}>
+          WINNER
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12,
+            marginTop: 8,
+          }}
+        >
           <span
             style={{
               width: 28,
@@ -905,11 +983,15 @@ function WinnerBanner({ winner, onReset }: { winner: Agent; onReset: () => void 
           <div>
             <div style={{ fontSize: 22, fontWeight: 700 }}>{winner.name}</div>
             <div style={{ fontSize: 12, opacity: 0.6 }}>
-              {TEAM_NAMES[winner.team]} · {winner.kills} kills · {winner.size.current.toFixed(1)} mass
+              {TEAM_NAMES[winner.team]} · {winner.kills} kills ·{' '}
+              {winner.size.current.toFixed(1)} mass
             </div>
           </div>
         </div>
-        <button onClick={onReset} style={{ ...btnStyle(false, '#10b981'), marginTop: 14 }}>
+        <button
+          onClick={onReset}
+          style={{ ...btnStyle(false, '#10b981'), marginTop: 14 }}
+        >
           New round
         </button>
       </div>
@@ -928,9 +1010,8 @@ export default function Agents() {
   const [tickN, setTickN] = useState(0);
   const [winner, setWinner] = useState<Agent | null>(null);
   const [controlledId, setControlledId] = useState<number | null>(null);
-  // Mouse position in WORLD coords. Updated on every pointermove; read by
-  // tick() each frame. A ref (not state) — no re-renders on mouse motion.
-  const mouseRef = useRef<Vec>({ x: 0, y: 0 });
+  // World-coord mouse — ref (not state) so motion doesn't trigger re-renders.
+  const mouseRef = useRef({ x: 0, y: 0 });
 
   const stageRef = useRef<HTMLDivElement>(null);
   const [world, setWorld] = useState<Vec>(() => ({
@@ -955,10 +1036,9 @@ export default function Agents() {
     };
   }, []);
 
-  // Pellets scale with agent count so density of food stays meaningful.
   const pelletCount = count * 2;
 
-  // Recreate agents/pellets on count change, world change, OR reset (seed bump).
+  // Recreate on count/world change or seed bump (reset).
   const agents = useMemo(
     () => Array.from({ length: count }, (_, i) => makeAgent(i, world)),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- seed deliberately invalidates the memo on reset
@@ -970,7 +1050,7 @@ export default function Agents() {
     [pelletCount, world, seed],
   );
 
-  // Reset round-state when agents identity changes (count change, world resize, or reset).
+  // Reset round-state on agent-identity change.
   useEffect(() => {
     killFeed.update([]);
     setWinner(null);
@@ -993,42 +1073,42 @@ export default function Agents() {
     };
   }, [controlledId, agents]);
 
-  // Tick loop. Stops on game over. Rate-gated by the module-scope `tickSpeed`
-  // signal — read directly inside the effect so speed changes don't restart
-  // the subscription (and don't need to be in the dep array).
+  // Tick loop, rate-gated by `tickSpeed.current` (read directly so speed
+  // changes don't restart the subscription).
   const frame = usePulseRefSignal('raf');
   const lastTickRef = useRef(0);
   useEffect(() => {
     if (!running || winner) return;
     lastTickRef.current = 0;
   }, [running, agents, pellets, world, winner, controlledId]);
-  useRefSignalEffect(
-    () => {
-      if (!running || winner) return;
-      const now = frame.elapsed;
-      const interval = 1000 / Math.max(1, tickSpeed.current);
-      if (now - lastTickRef.current >= interval) {
-        const result = tick(agents, pellets, world, {
-          agentId: controlledId,
-          mouse: mouseRef.current,
-        });
-        lastTickRef.current = now;
-        setTickN((n) => n + 1);
-        if (result.gameOver) {
-          setWinner(result.survivor);
-        }
+  useRefSignalEffect(() => {
+    if (!running || winner) return;
+    const now = frame.elapsed;
+    const interval = 1000 / Math.max(1, tickSpeed.current);
+    if (now - lastTickRef.current >= interval) {
+      const result = tick(agents, pellets, world, {
+        agentId: controlledId,
+        mouse: mouseRef.current,
+      });
+      lastTickRef.current = now;
+      setTickN((n) => n + 1);
+      if (result.gameOver) {
+        setWinner(result.survivor);
       }
-    },
-    [frame, running, agents, pellets, world, winner, controlledId],
-  );
+    }
+  }, [frame, running, agents, pellets, world, winner, controlledId]);
 
-  const reset = () => setSeed((s) => s + 1);
+  const reset = () => {
+    setSeed((s) => s + 1);
+  };
 
   return (
     <div style={pageStyle}>
       <div style={toolbarStyle}>
         <button
-          onClick={() => setRunning((r) => !r)}
+          onClick={() => {
+            setRunning((r) => !r);
+          }}
           disabled={!!winner}
           style={btnStyle(running && !winner, running ? '#f97316' : '#10b981')}
         >
@@ -1042,7 +1122,9 @@ export default function Agents() {
           Agents
           <select
             value={count}
-            onChange={(e) => setCount(+e.target.value as Count)}
+            onChange={(e) => {
+              setCount(+e.target.value as Count);
+            }}
             style={selectStyle}
           >
             {COUNTS.map((c) => (
@@ -1068,23 +1150,19 @@ export default function Agents() {
       </div>
 
       <div style={hintStyle}>
-        {count} agents in 4 teams, permadeath. Bigger eats smaller (any team).
-        Pellets refill mass. <b>Click any agent to take control</b> — it&apos;ll steer
-        toward your cursor; auto-released when it dies. Each agent owns four signals
-        (<code style={codeStyle}>position</code>, <code style={codeStyle}>size</code>,{' '}
-        <code style={codeStyle}>alive</code>, <code style={codeStyle}>callTarget</code>)
-        — that&apos;s {count * 4} reactive cells. <b>Pack hunting via signals:</b> when
-        an agent locks a target it broadcasts via <code style={codeStyle}>callTarget</code>;
-        same-team allies within hearing range adopt the call when they have no target
-        of their own — propagating outward each tick. The dashed lines visualize
-        live calls; their subscriptions follow the called target dynamically via{' '}
-        <code style={codeStyle}>trackSignals</code>. The reactive panels each subscribe
-        only to their slice — TeamRows re-render only when their team changes; the
-        Killcam subscribes only to <code style={codeStyle}>killFeed</code>; no central
-        re-render anywhere.
+        {count} agents, 4 teams, permadeath — bigger eats smaller.{' '}
+        <b>Click any agent</b> to control it (steers toward cursor). Each agent
+        owns 4 signals = {count * 4} reactive cells. <b>Pack hunting:</b> agents
+        broadcast their target via <code style={codeStyle}>callTarget</code>;
+        teammates within hearing range adopt it. Dashed lines follow each call
+        through <code style={codeStyle}>trackSignals</code>. Panels subscribe
+        only to their slice — no central re-render.
       </div>
 
-      <div ref={stageRef} style={{ flex: 1, overflow: 'hidden', position: 'relative' }}>
+      <div
+        ref={stageRef}
+        style={{ flex: 1, overflow: 'hidden', position: 'relative' }}
+      >
         <svg
           viewBox={`0 0 ${world.x} ${world.y}`}
           preserveAspectRatio="none"
@@ -1133,9 +1211,6 @@ export default function Agents() {
 // UI bits
 // ---------------------------------------------------------------
 
-// SpeedControl — controlled slider over the module-scope `tickSpeed` signal.
-// Re-renders only on speed changes (its own input or anything else updating
-// the signal). The RAF loop reads `tickSpeed.current` directly each frame.
 function SpeedControl() {
   useRefSignalRender([tickSpeed]);
   return (
@@ -1146,10 +1221,20 @@ function SpeedControl() {
         min={1}
         max={120}
         value={tickSpeed.current}
-        onChange={(e) => tickSpeed.update(+e.target.value)}
+        onChange={(e) => {
+          tickSpeed.update(+e.target.value);
+        }}
         style={{ width: 100 }}
       />
-      <span style={{ fontFamily: 'monospace', fontSize: 11, opacity: 0.7, minWidth: 36, textAlign: 'right' }}>
+      <span
+        style={{
+          fontFamily: 'monospace',
+          fontSize: 11,
+          opacity: 0.7,
+          minWidth: 36,
+          textAlign: 'right',
+        }}
+      >
         {tickSpeed.current}/s
       </span>
     </label>
@@ -1171,16 +1256,26 @@ function Dot({ hue }: { hue: number }) {
   );
 }
 
-function Stat({ label, value, highlight }: { label: string; value: string | number; highlight?: boolean }) {
+function Stat({
+  label,
+  value,
+  highlight,
+}: {
+  label: string;
+  value: string | number;
+  highlight?: boolean;
+}) {
   return (
-    <span style={{
-      background: '#0d1117',
-      padding: '4px 10px',
-      borderRadius: 4,
-      fontSize: 12,
-      fontFamily: 'monospace',
-      border: highlight ? '1px solid #4a9eff' : '1px solid transparent',
-    }}>
+    <span
+      style={{
+        background: '#0d1117',
+        padding: '4px 10px',
+        borderRadius: 4,
+        fontSize: 12,
+        fontFamily: 'monospace',
+        border: highlight ? '1px solid #4a9eff' : '1px solid transparent',
+      }}
+    >
       {label} <b style={{ color: highlight ? '#4a9eff' : '#fff' }}>{value}</b>
     </span>
   );
@@ -1239,7 +1334,10 @@ const selectStyle: React.CSSProperties = {
   fontSize: 12,
 };
 
-function panelStyle(corner: 'top' | 'left' | 'bottom-right', offset: number): React.CSSProperties {
+function panelStyle(
+  corner: 'top' | 'left' | 'bottom-right',
+  offset: number,
+): React.CSSProperties {
   const base: React.CSSProperties = {
     position: 'absolute',
     background: 'rgba(13, 17, 23, 0.85)',

--- a/demo/fps.tsx
+++ b/demo/fps.tsx
@@ -1,59 +1,42 @@
-// demo/fps.tsx
-//
-// Reusable FPS badge — one shared pulse signal, one rounded-fps signal, any
-// number of consumers. Drop <FpsBadge /> anywhere; or call useFps() for custom
-// UI.
-//
-// The pulse subscription is ref-counted by consumer mounts: zero consumers ⇒
-// no watcher ⇒ pulse subscriber count stays at zero ⇒ pulse doesn't tick. The
-// first useFps() mount installs the watcher; the last unmount tears it down.
+// FPS badge — `<FpsBadge />`, or `useFps()` for custom UI. Pass a custom pulse
+// via `src`; defaults to a shared 'raf' pulse.
 
-import { useEffect } from 'react';
+import { useRef, useState } from 'react';
 import {
   createPulseRefSignal,
-  createRefSignal,
-  useRefSignalRender,
-  watch,
+  useRefSignalEffect,
+  type PulseRefSignal,
 } from 'react-refsignal';
 
-const fpsSignal = createRefSignal(0);
-const frame = createPulseRefSignal('raf');
+const defaultPulse = createPulseRefSignal('raf');
 
-let consumers = 0;
-let stopWatching: (() => void) | null = null;
+export function useFps(src?: PulseRefSignal): number {
+  const pulse = src ?? defaultPulse;
+  const [fps, setFps] = useState(0);
+  const pulseRef = useRef<PulseRefSignal | null>(null);
+  const stateRef = useRef({ frames: 0, last: 0 });
 
-function startWatching(): () => void {
-  let frames = 0;
-  let lastSampleAt = 0;
-  return watch(frame, () => {
-    frames++;
-    const windowMs = frame.elapsed - lastSampleAt;
-    if (windowMs >= 1000) {
-      fpsSignal.update(Math.round((frames * 1000) / windowMs));
-      frames = 0;
-      lastSampleAt = frame.elapsed;
+  useRefSignalEffect(() => {
+    // First tick after mount or pulse swap — anchor `last` to the new pulse's elapsed.
+    if (pulseRef.current !== pulse) {
+      pulseRef.current = pulse;
+      stateRef.current = { frames: 0, last: pulse.elapsed };
+      return;
     }
-  });
+    const s = stateRef.current;
+    s.frames++;
+    if (pulse.elapsed - s.last >= 1000) {
+      setFps(Math.round((s.frames * 1000) / (pulse.elapsed - s.last)));
+      s.frames = 0;
+      s.last = pulse.elapsed;
+    }
+  }, [pulse]);
+
+  return fps;
 }
 
-export function useFps(): number {
-  useEffect(() => {
-    if (consumers === 0) stopWatching = startWatching();
-    consumers++;
-    return () => {
-      consumers--;
-      if (consumers === 0) {
-        stopWatching?.();
-        stopWatching = null;
-      }
-    };
-  }, []);
-  useRefSignalRender([fpsSignal]);
-  return fpsSignal.current;
-}
-
-export function FpsBadge() {
-  const fps = useFps();
+export function FpsBadge({ src }: { src?: PulseRefSignal }) {
+  const fps = useFps(src);
   return (
     <span style={badgeStyle}>
       fps <b>{fps || '--'}</b>

--- a/demo/game-of-life.tsx
+++ b/demo/game-of-life.tsx
@@ -1,17 +1,13 @@
-// demo/game-of-life.tsx
-//
-// Conway's Game of Life — one signal per cell, age-based coloring, batched ticks.
-//
-// What to watch:
-//   - Open React DevTools Profiler. Hit a pattern, run a tick.
-//   - Out of N×N cells, only the ~5–15% that *changed* re-render.
-//   - The "changed/tick" counter shows it live. That's the whole point.
+// Conway's Game of Life — one signal per cell. Only the ~5-15% of cells that
+// flip per tick re-render (DOM mode) or repaint (Canvas mode). Open the
+// Profiler and watch the "changed/tick" counter live.
 
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   batch,
   createRefSignal,
   usePulseRefSignal,
+  useRefSignal,
   useRefSignalEffect,
   type RefSignal,
 } from 'react-refsignal';
@@ -32,48 +28,111 @@ const GLIDER: Cells = [
 ];
 
 const PULSAR: Cells = [
-  [0, 2], [0, 3], [0, 4], [0, 8], [0, 9], [0, 10],
-  [2, 0], [2, 5], [2, 7], [2, 12],
-  [3, 0], [3, 5], [3, 7], [3, 12],
-  [4, 0], [4, 5], [4, 7], [4, 12],
-  [5, 2], [5, 3], [5, 4], [5, 8], [5, 9], [5, 10],
-  [7, 2], [7, 3], [7, 4], [7, 8], [7, 9], [7, 10],
-  [8, 0], [8, 5], [8, 7], [8, 12],
-  [9, 0], [9, 5], [9, 7], [9, 12],
-  [10, 0], [10, 5], [10, 7], [10, 12],
-  [12, 2], [12, 3], [12, 4], [12, 8], [12, 9], [12, 10],
+  [0, 2],
+  [0, 3],
+  [0, 4],
+  [0, 8],
+  [0, 9],
+  [0, 10],
+  [2, 0],
+  [2, 5],
+  [2, 7],
+  [2, 12],
+  [3, 0],
+  [3, 5],
+  [3, 7],
+  [3, 12],
+  [4, 0],
+  [4, 5],
+  [4, 7],
+  [4, 12],
+  [5, 2],
+  [5, 3],
+  [5, 4],
+  [5, 8],
+  [5, 9],
+  [5, 10],
+  [7, 2],
+  [7, 3],
+  [7, 4],
+  [7, 8],
+  [7, 9],
+  [7, 10],
+  [8, 0],
+  [8, 5],
+  [8, 7],
+  [8, 12],
+  [9, 0],
+  [9, 5],
+  [9, 7],
+  [9, 12],
+  [10, 0],
+  [10, 5],
+  [10, 7],
+  [10, 12],
+  [12, 2],
+  [12, 3],
+  [12, 4],
+  [12, 8],
+  [12, 9],
+  [12, 10],
 ];
 
 const GOSPER: Cells = [
-  [4, 0], [4, 1], [5, 0], [5, 1],
-  [4, 10], [5, 10], [6, 10],
-  [3, 11], [7, 11],
-  [2, 12], [2, 13], [8, 12], [8, 13],
+  [4, 0],
+  [4, 1],
+  [5, 0],
+  [5, 1],
+  [4, 10],
+  [5, 10],
+  [6, 10],
+  [3, 11],
+  [7, 11],
+  [2, 12],
+  [2, 13],
+  [8, 12],
+  [8, 13],
   [5, 14],
-  [3, 15], [7, 15],
-  [4, 16], [5, 16], [6, 16],
+  [3, 15],
+  [7, 15],
+  [4, 16],
+  [5, 16],
+  [6, 16],
   [5, 17],
-  [2, 20], [3, 20], [4, 20],
-  [2, 21], [3, 21], [4, 21],
-  [1, 22], [5, 22],
-  [0, 24], [1, 24], [5, 24], [6, 24],
-  [2, 34], [2, 35], [3, 34], [3, 35],
+  [2, 20],
+  [3, 20],
+  [4, 20],
+  [2, 21],
+  [3, 21],
+  [4, 21],
+  [1, 22],
+  [5, 22],
+  [0, 24],
+  [1, 24],
+  [5, 24],
+  [6, 24],
+  [2, 34],
+  [2, 35],
+  [3, 34],
+  [3, 35],
 ];
 
 const R_PENTOMINO: Cells = [
-  [0, 1], [0, 2],
-  [1, 0], [1, 1],
+  [0, 1],
+  [0, 2],
+  [1, 0],
+  [1, 1],
   [2, 1],
 ];
 
 type Pattern = { name: string; cells: Cells | 'random' };
 
 const PATTERNS: Pattern[] = [
-  { name: 'Glider',      cells: GLIDER },
-  { name: 'Pulsar',      cells: PULSAR },
-  { name: 'Gosper gun',  cells: GOSPER },
+  { name: 'Glider', cells: GLIDER },
+  { name: 'Pulsar', cells: PULSAR },
+  { name: 'Gosper gun', cells: GOSPER },
   { name: 'R-pentomino', cells: R_PENTOMINO },
-  { name: 'Random 30%',  cells: 'random' },
+  { name: 'Random 30%', cells: 'random' },
 ];
 
 // ---------------------------------------------------------------
@@ -90,8 +149,8 @@ function dimsOf(grid: RefSignal<number>[][]): { w: number; h: number } {
   return { h: grid.length, w: grid[0]?.length ?? 0 };
 }
 
+// Cell value is "age": 0 = dead, n > 0 = alive for n ticks (drives coloring).
 function makeGrid(w: number, h: number): RefSignal<number>[][] {
-  // One signal per cell. Value is "age": 0 = dead, n > 0 = alive for n ticks.
   const g: RefSignal<number>[][] = [];
   for (let y = 0; y < h; y++) {
     const row: RefSignal<number>[] = [];
@@ -136,7 +195,7 @@ function placePattern(grid: RefSignal<number>[][], pattern: Pattern) {
 
 function tick(grid: RefSignal<number>[][]): { changed: number; alive: number } {
   const { w, h } = dimsOf(grid);
-  // Read current state into a flat buffer (no signal subscriptions involved here).
+  // Snapshot to a flat buffer first — neighbour reads must not see partial updates.
   const cur = new Uint8Array(w * h);
   for (let y = 0; y < h; y++) {
     for (let x = 0; x < w; x++) {
@@ -155,7 +214,7 @@ function tick(grid: RefSignal<number>[][]): { changed: number; alive: number } {
             if (dx === 0 && dy === 0) continue;
             const nx = (x + dx + w) % w;
             const ny = (y + dy + h) % h;
-            n += cur[ny * w + nx];
+            n += cur[ny * w + nx]!;
           }
         }
         const wasAlive = cur[y * w + x] === 1;
@@ -190,9 +249,8 @@ function patternFits(pattern: Pattern, w: number, h: number): boolean {
 const DEAD = '#0b0d18';
 const DEAD_RGB: [number, number, number] = [0x0b, 0x0d, 0x18];
 
-// Single source of truth for the age → HSL mapping.
+// Age → HSL. Sweep cyan (newborn) → green → yellow → orange → red (old).
 function hslAtAge(age: number): { h: number; s: number; l: number } {
-  // Sweep from cyan (newborn) → green → yellow → orange → red (old).
   const t = Math.min(1, age / 30);
   return {
     h: 190 - t * 190,
@@ -207,14 +265,15 @@ function ageColor(age: number): string {
   return `hsl(${h.toFixed(0)}, ${s}%, ${l.toFixed(0)}%)`;
 }
 
-// HSL → RGB (h: 0-360, s/l: 0-100), returns 0-255 ints.
 function hslToRgb(h: number, s: number, l: number): [number, number, number] {
   const sN = s / 100;
   const lN = l / 100;
   const c = (1 - Math.abs(2 * lN - 1)) * sN;
   const hp = h / 60;
   const x = c * (1 - Math.abs((hp % 2) - 1));
-  let r = 0, g = 0, b = 0;
+  let r = 0,
+    g = 0,
+    b = 0;
   if (hp < 1) [r, g, b] = [c, x, 0];
   else if (hp < 2) [r, g, b] = [x, c, 0];
   else if (hp < 3) [r, g, b] = [0, c, x];
@@ -229,11 +288,11 @@ function hslToRgb(h: number, s: number, l: number): [number, number, number] {
   ];
 }
 
-// Precomputed Uint32 (ABGR little-endian) LUT for canvas pixel writes.
-// Ages > 30 saturate to red.
+// ABGR little-endian LUT for canvas pixel writes. Ages > 30 clamp to red.
 const COLOR_LUT_U32: Uint32Array = (() => {
   const lut = new Uint32Array(31);
-  const pack = (r: number, g: number, b: number) => ((0xff << 24) | (b << 16) | (g << 8) | r) >>> 0;
+  const pack = (r: number, g: number, b: number) =>
+    ((0xff << 24) | (b << 16) | (g << 8) | r) >>> 0;
   lut[0] = pack(...DEAD_RGB);
   for (let i = 1; i <= 30; i++) {
     const { h, s, l } = hslAtAge(i);
@@ -247,22 +306,28 @@ function ageColorU32(age: number): number {
   return COLOR_LUT_U32[Math.min(age, 30)];
 }
 
-// ---------------------------------------------------------------
-// Cell — subscribes to one signal, re-renders only when its age changes.
-// ---------------------------------------------------------------
+// Cell subscribes to one signal; only its own update fires the effect.
 
 let _cellRenders = 0;
-function bumpRender() { _cellRenders++; }
-function takeRenders() { const r = _cellRenders; _cellRenders = 0; return r; }
+function bumpRender() {
+  _cellRenders++;
+}
+function takeRenders() {
+  const r = _cellRenders;
+  _cellRenders = 0;
+  return r;
+}
 
-const Cell = memo(function Cell({ sig, onPaint }: {
+const Cell = memo(function Cell({
+  sig,
+  onPaint,
+}: {
   sig: RefSignal<number>;
   onPaint: (sig: RefSignal<number>) => void;
 }) {
   bumpRender();
   const ref = useRef<HTMLDivElement>(null);
-  // Imperative: signal updates write style.background directly. React renders
-  // this component once at mount and (almost) never again.
+  // Imperative paint — React renders this once at mount, the signal does the rest.
   useRefSignalEffect(() => {
     const el = ref.current;
     if (el) el.style.background = ageColor(sig.current);
@@ -270,20 +335,23 @@ const Cell = memo(function Cell({ sig, onPaint }: {
   return (
     <div
       ref={ref}
-      onPointerDown={() => onPaint(sig)}
-      onPointerEnter={(e) => { if (e.buttons === 1) onPaint(sig); }}
+      onPointerDown={() => {
+        onPaint(sig);
+      }}
+      onPointerEnter={(e) => {
+        if (e.buttons === 1) onPaint(sig);
+      }}
       style={{ background: ageColor(sig.current) }}
     />
   );
 });
 
-// ---------------------------------------------------------------
-// CanvasGrid — same one-signal-per-cell model, single canvas observer.
-// Subscribes to every cell; on signal fire, marks pixel dirty + schedules rAF.
-// rAF flushes a single putImageData. ~100x faster than per-cell DOM writes.
-// ---------------------------------------------------------------
-
-function CanvasGrid({ grid, onPaint }: {
+// Same per-cell signal model, but listeners mark pixels dirty and one rAF
+// flush does a single putImageData per frame — ~100× faster than DOM mode.
+function CanvasGrid({
+  grid,
+  onPaint,
+}: {
   grid: RefSignal<number>[][];
   onPaint: (sig: RefSignal<number>) => void;
 }) {
@@ -292,12 +360,10 @@ function CanvasGrid({ grid, onPaint }: {
   onPaintRef.current = onPaint;
   const { w, h } = dimsOf(grid);
 
-  // Per-cell listeners push the changed index into `dirty` and bump
-  // `dirtyBump`. The flush below subscribes to dirtyBump with `rAF: true`,
-  // which collapses N bumps within a frame into a single flush — the lib
-  // handles the rAF scheduling that used to be a manual rafId/cancel pair.
-  const dirty = useMemo(() => new Set<number>(), []);
-  const dirtyBump = useMemo(() => createRefSignal(0), []);
+  // Per-cell listeners push indices into `dirty` and bump `dirtyBump`. The
+  // flush below subscribes to it with `rAF: true` — N bumps coalesce into one frame.
+  const dirty = useRef(new Set<number>()).current;
+  const dirtyBump = useRefSignal(0);
   const paintRef = useRef<{
     ctx: CanvasRenderingContext2D;
     pixels: Uint32Array;
@@ -317,7 +383,6 @@ function CanvasGrid({ grid, onPaint }: {
     paintRef.current = { ctx, pixels, imgData };
     dirty.clear();
 
-    // Initial paint — fill all pixels and putImageData once.
     for (let y = 0; y < h; y++) {
       for (let x = 0; x < w; x++) {
         pixels[y * w + x] = ageColorU32(grid[y][x].current);
@@ -325,7 +390,6 @@ function CanvasGrid({ grid, onPaint }: {
     }
     ctx.putImageData(imgData, 0, 0);
 
-    // Subscribe per cell — listener pushes to dirty set + bumps the flush.
     const unsubs: Array<() => void> = [];
     for (let y = 0; y < h; y++) {
       for (let x = 0; x < w; x++) {
@@ -336,7 +400,9 @@ function CanvasGrid({ grid, onPaint }: {
           dirtyBump.notify();
         };
         sig.subscribe(listener);
-        unsubs.push(() => sig.unsubscribe(listener));
+        unsubs.push(() => {
+          sig.unsubscribe(listener);
+        });
       }
     }
 
@@ -407,8 +473,7 @@ export default function GameOfLife() {
   const [tickN, setTickN] = useState(0);
   const [stats, setStats] = useState({ alive: 0, changed: 0, rps: 0 });
 
-  // Stage container size for canvas mode (rectangular, fills available space).
-  // Initial fallback uses window dims; ResizeObserver corrects after mount.
+  // Canvas-mode stage size; initial fallback corrected after mount.
   const stageRef = useRef<HTMLDivElement>(null);
   const [stageDims, setStageDims] = useState<{ w: number; h: number }>(() => ({
     w: typeof window !== 'undefined' ? window.innerWidth - 32 : 1024,
@@ -424,10 +489,8 @@ export default function GameOfLife() {
       const h = Math.floor(r.height);
       setStageDims((prev) => (prev.w === w && prev.h === h ? prev : { w, h }));
     };
-    // Measure after first paint so layout has settled.
+    // Measure post-paint; only re-measure on viewport resize, not toolbar reflows.
     const rafId = requestAnimationFrame(measure);
-    // Only re-measure on viewport resize — NOT on internal toolbar reflows
-    // (which would fire constantly as stats text width changes).
     window.addEventListener('resize', measure);
     return () => {
       cancelAnimationFrame(rafId);
@@ -435,7 +498,6 @@ export default function GameOfLife() {
     };
   }, []);
 
-  // Logical grid dimensions per mode.
   const dims = useMemo(() => {
     if (mode === 'dom') return { w: size, h: size };
     return {
@@ -444,21 +506,19 @@ export default function GameOfLife() {
     };
   }, [mode, size, cellPx, stageDims]);
 
-  // Recreate grid on dims change.
   const grid = useMemo(() => makeGrid(dims.w, dims.h), [dims.w, dims.h]);
 
-  // Seed with a pulsar (or glider if it doesn't fit).
+  // Seed with pulsar, fall back to glider if it doesn't fit.
   useEffect(() => {
-    const initial =
-      patternFits(PATTERNS[1], dims.w, dims.h) ? PATTERNS[1] : PATTERNS[0];
+    const initial = patternFits(PATTERNS[1], dims.w, dims.h)
+      ? PATTERNS[1]
+      : PATTERNS[0];
     placePattern(grid, initial);
     setTickN(0);
     setStats({ alive: 0, changed: 0, rps: 0 });
   }, [grid, dims.w, dims.h]);
 
-  // Pulse-driven tick loop with target-tps gating. The pulse fires every
-  // animation frame at the display's native rate; we gate ticks by the
-  // selected `speed` (ticks/sec) using `frame.elapsed` as the clock.
+  // Tick loop, rate-gated against `frame.elapsed`.
   const frame = usePulseRefSignal('raf');
   const lastTickRef = useRef(0);
   const sampleStartRef = useRef(0);
@@ -468,38 +528,37 @@ export default function GameOfLife() {
     sampleStartRef.current = 0;
     takeRenders();
   }, [running, speed, grid]);
-  useRefSignalEffect(
-    () => {
-      if (!running) return;
-      const now = frame.elapsed;
-      const interval = 1000 / speed;
-      let alive = stats.alive;
-      let changed = stats.changed;
-      let didTick = false;
-      if (now - lastTickRef.current >= interval) {
-        const r = tick(grid);
-        alive = r.alive;
-        changed = r.changed;
-        lastTickRef.current = now;
-        didTick = true;
-      }
-      if (now - sampleStartRef.current >= 1000) {
-        const rps = takeRenders();
-        setStats({ alive, changed, rps });
-        sampleStartRef.current = now;
-      } else if (didTick) {
-        setStats((s) => ({ ...s, alive, changed }));
-      }
-      if (didTick) setTickN((n) => n + 1);
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- stats setter is stable; timing state held in refs
-    [frame, running, speed, grid],
-  );
+  useRefSignalEffect(() => {
+    if (!running) return;
+    const now = frame.elapsed;
+    const interval = 1000 / speed;
+    let alive = stats.alive;
+    let changed = stats.changed;
+    let didTick = false;
+    if (now - lastTickRef.current >= interval) {
+      const r = tick(grid);
+      alive = r.alive;
+      changed = r.changed;
+      lastTickRef.current = now;
+      didTick = true;
+    }
+    if (now - sampleStartRef.current >= 1000) {
+      const rps = takeRenders();
+      setStats({ alive, changed, rps });
+      sampleStartRef.current = now;
+    } else if (didTick) {
+      setStats((s) => ({ ...s, alive, changed }));
+    }
+    if (didTick) setTickN((n) => n + 1);
+  }, [frame, running, speed, grid]);
 
-  const onPaint = useCallback((sig: RefSignal<number>) => {
-    if (running) return; // only paint when paused
-    sig.update(sig.current > 0 ? 0 : 1);
-  }, [running]);
+  const onPaint = useCallback(
+    (sig: RefSignal<number>) => {
+      if (running) return; // only paint when paused
+      sig.update(sig.current > 0 ? 0 : 1);
+    },
+    [running],
+  );
 
   const stepOnce = useCallback(() => {
     const { alive, changed } = tick(grid);
@@ -508,7 +567,8 @@ export default function GameOfLife() {
   }, [grid]);
 
   const total = dims.w * dims.h;
-  const changedPct = total > 0 ? ((stats.changed / total) * 100).toFixed(1) : '0';
+  const changedPct =
+    total > 0 ? ((stats.changed / total) * 100).toFixed(1) : '0';
 
   return (
     <div style={pageStyle}>
@@ -519,7 +579,9 @@ export default function GameOfLife() {
             <button
               key={p.name}
               disabled={!ok}
-              onClick={() => placePattern(grid, p)}
+              onClick={() => {
+                placePattern(grid, p);
+              }}
               style={btnStyle(false, '#4a9eff', !ok)}
               title={ok ? '' : `Doesn't fit ${dims.w}×${dims.h}`}
             >
@@ -528,7 +590,9 @@ export default function GameOfLife() {
           );
         })}
         <button
-          onClick={() => clearGrid(grid)}
+          onClick={() => {
+            clearGrid(grid);
+          }}
           style={btnStyle(false, '#64748b')}
         >
           Clear
@@ -537,7 +601,9 @@ export default function GameOfLife() {
         <span style={sep} />
 
         <button
-          onClick={() => setRunning((r) => !r)}
+          onClick={() => {
+            setRunning((r) => !r);
+          }}
           style={btnStyle(running, running ? '#f97316' : '#10b981')}
         >
           {running ? 'Pause' : 'Play'}
@@ -557,23 +623,39 @@ export default function GameOfLife() {
             min={1}
             max={60}
             value={speed}
-            onChange={(e) => setSpeed(+e.target.value)}
+            onChange={(e) => {
+              setSpeed(+e.target.value);
+            }}
           />
           <span style={tinyMono}>{speed}/s</span>
         </label>
 
         <span style={sep} />
 
-        <span style={{ display: 'flex', gap: 0, borderRadius: 6, overflow: 'hidden' }}>
+        <span
+          style={{
+            display: 'flex',
+            gap: 0,
+            borderRadius: 6,
+            overflow: 'hidden',
+          }}
+        >
           <button
-            onClick={() => setMode('dom')}
+            onClick={() => {
+              setMode('dom');
+            }}
             style={{ ...btnStyle(mode === 'dom', '#4a9eff'), borderRadius: 0 }}
           >
             DOM
           </button>
           <button
-            onClick={() => setMode('canvas')}
-            style={{ ...btnStyle(mode === 'canvas', '#a855f7'), borderRadius: 0 }}
+            onClick={() => {
+              setMode('canvas');
+            }}
+            style={{
+              ...btnStyle(mode === 'canvas', '#a855f7'),
+              borderRadius: 0,
+            }}
           >
             Canvas
           </button>
@@ -584,7 +666,9 @@ export default function GameOfLife() {
             Size
             <select
               value={size}
-              onChange={(e) => setSize(+e.target.value as Size)}
+              onChange={(e) => {
+                setSize(+e.target.value as Size);
+              }}
               style={selectStyle}
             >
               {SIZES.map((s) => (
@@ -599,7 +683,9 @@ export default function GameOfLife() {
             Cell px
             <select
               value={cellPx}
-              onChange={(e) => setCellPx(+e.target.value as CellPx)}
+              onChange={(e) => {
+                setCellPx(+e.target.value as CellPx);
+              }}
               style={selectStyle}
             >
               {CELL_PX.map((p) => (
@@ -615,31 +701,31 @@ export default function GameOfLife() {
           <Stat label="grid" value={`${dims.w}×${dims.h}`} />
           <Stat label="tick" value={tickN} />
           <Stat label="alive" value={`${stats.alive}/${total}`} />
-          <Stat label="changed/tick" value={`${stats.changed} (${changedPct}%)`} highlight />
+          <Stat
+            label="changed/tick"
+            value={`${stats.changed} (${changedPct}%)`}
+            highlight
+          />
           <Stat label="renders/s" value={stats.rps || '--'} />
           <FpsBadge />
         </span>
       </div>
 
       <div style={hintStyle}>
-        Both modes: zero React renders post-mount (<b>renders/s</b> ≈ 0). The signal listener
-        does the work directly.
-        {' '}
+        Zero React renders post-mount — the signal listener writes directly.{' '}
         {mode === 'dom' ? (
           <>
-            <b>DOM</b>: <code style={codeStyle}>useRefSignalEffect</code> writes{' '}
-            <code style={codeStyle}>style.background</code> on each changed cell — browser does N
-            independent style recalcs + paints per tick. Bottleneck at 100×100 + Random.
+            <b>DOM</b>: per-cell <code style={codeStyle}>style.background</code>{' '}
+            writes (bottlenecks at 100×100 + Random).
           </>
         ) : (
           <>
-            <b>Canvas</b>: rectangular grid auto-fitted to the viewport ({dims.w}×{dims.h} ={' '}
-            {total.toLocaleString()} signals). Each cell&apos;s listener marks a pixel dirty +
-            schedules rAF; one <code style={codeStyle}>putImageData</code> per frame. Try Random +
-            60/s — should hit your monitor&apos;s refresh rate.
+            <b>Canvas</b>: {dims.w}×{dims.h} = {total.toLocaleString()} signals;
+            one <code style={codeStyle}>putImageData</code> per frame. Try
+            Random + 60/s.
           </>
-        )}
-        {' '}Click/drag (paused) to paint.
+        )}{' '}
+        Click/drag (paused) to paint.
       </div>
 
       <div ref={stageRef} style={{ flex: 1, overflow: 'hidden', padding: 8 }}>
@@ -660,10 +746,14 @@ export default function GameOfLife() {
               touchAction: 'none',
               userSelect: 'none',
             }}
-            onPointerLeave={(e) => e.currentTarget.releasePointerCapture?.(e.pointerId)}
+            onPointerLeave={(e) => {
+              e.currentTarget.releasePointerCapture(e.pointerId);
+            }}
           >
             {grid.map((row, y) =>
-              row.map((sig, x) => <Cell key={`${y}-${x}`} sig={sig} onPaint={onPaint} />),
+              row.map((sig, x) => (
+                <Cell key={`${y}-${x}`} sig={sig} onPaint={onPaint} />
+              )),
             )}
           </div>
         ) : (
@@ -678,16 +768,26 @@ export default function GameOfLife() {
 // UI bits
 // ---------------------------------------------------------------
 
-function Stat({ label, value, highlight }: { label: string; value: string | number; highlight?: boolean }) {
+function Stat({
+  label,
+  value,
+  highlight,
+}: {
+  label: string;
+  value: string | number;
+  highlight?: boolean;
+}) {
   return (
-    <span style={{
-      background: '#0d1117',
-      padding: '4px 10px',
-      borderRadius: 4,
-      fontSize: 12,
-      fontFamily: 'monospace',
-      border: highlight ? '1px solid #4a9eff' : '1px solid transparent',
-    }}>
+    <span
+      style={{
+        background: '#0d1117',
+        padding: '4px 10px',
+        borderRadius: 4,
+        fontSize: 12,
+        fontFamily: 'monospace',
+        border: highlight ? '1px solid #4a9eff' : '1px solid transparent',
+      }}
+    >
       {label} <b style={{ color: highlight ? '#4a9eff' : '#fff' }}>{value}</b>
     </span>
   );
@@ -737,9 +837,18 @@ const selectStyle: React.CSSProperties = {
   fontSize: 12,
 };
 
-const tinyMono: React.CSSProperties = { fontFamily: 'monospace', fontSize: 11, opacity: 0.7, minWidth: 32 };
+const tinyMono: React.CSSProperties = {
+  fontFamily: 'monospace',
+  fontSize: 11,
+  opacity: 0.7,
+  minWidth: 32,
+};
 
-const sep: React.CSSProperties = { width: 1, height: 20, background: '#334155' };
+const sep: React.CSSProperties = {
+  width: 1,
+  height: 20,
+  background: '#334155',
+};
 
 const codeStyle: React.CSSProperties = {
   padding: '1px 6px',
@@ -749,7 +858,11 @@ const codeStyle: React.CSSProperties = {
   background: 'rgba(255,255,255,0.1)',
 };
 
-function btnStyle(active: boolean, color: string, disabled = false): React.CSSProperties {
+function btnStyle(
+  active: boolean,
+  color: string,
+  disabled = false,
+): React.CSSProperties {
   return {
     padding: '5px 12px',
     border: 'none',

--- a/demo/graph-benchmark.tsx
+++ b/demo/graph-benchmark.tsx
@@ -1,12 +1,5 @@
-// demo/graph-benchmark.tsx
-//
-// Draggable-graph benchmark: RefSignal vs Jotai vs Zustand vs React+memo.
-// Run locally:  npm run dev
-// Or paste into a Vite + React StackBlitz (install react-refsignal, zustand, jotai).
-//
-// What to watch:
-//   - Crank the slider to 500-2000 nodes and drag a node in each mode.
-//   - Compare FPS, renders/sec, and the Chrome profiler flame chart.
+// Draggable-graph benchmark — RefSignal vs Jotai vs Zustand vs React+memo.
+// Crank the slider, drag a node in each mode, compare FPS and renders/sec.
 
 import React, {
   useState,
@@ -77,51 +70,103 @@ function barW(id: number) {
 }
 
 let _renders = 0;
-function bumpRender() { _renders++; }
-function getRenders() { return _renders; }
-function resetRenders() { _renders = 0; }
+function bumpRender() {
+  _renders++;
+}
+function getRenders() {
+  return _renders;
+}
+function resetRenders() {
+  _renders = 0;
+}
 
-// ---------------------------------------------------------------
-// Accent colours
-// ---------------------------------------------------------------
-
+// Accent colours per mode.
 const SIG_C = '#4a9eff';
 const JOTAI_C = '#a855f7';
 const ZUS_C = '#f59e0b';
 const REACT_C = '#ff6b4a';
 
-// ---------------------------------------------------------------
-// Shared node SVG body (8 child elements)
-// ---------------------------------------------------------------
-
+// Shared node body — 8 SVG children, identical layout across modes.
 function nodeInner(id: number, accent: string) {
   return (
     <>
-      <rect x={-24} y={-16} width={48} height={32} rx={4} fill="#0f172a" stroke="#334155" strokeWidth={0.75} />
-      <line x1={-20} y1={-8} x2={20} y2={-8} stroke={accent} strokeWidth={1.5} />
-      <text y={-10.5} textAnchor="middle" fill="#e2e8f0" fontSize={7} fontWeight="600" pointerEvents="none">{id}</text>
-      <text y={0.5} textAnchor="middle" fill="#64748b" fontSize={5.5} pointerEvents="none">process</text>
+      <rect
+        x={-24}
+        y={-16}
+        width={48}
+        height={32}
+        rx={4}
+        fill="#0f172a"
+        stroke="#334155"
+        strokeWidth={0.75}
+      />
+      <line
+        x1={-20}
+        y1={-8}
+        x2={20}
+        y2={-8}
+        stroke={accent}
+        strokeWidth={1.5}
+      />
+      <text
+        y={-10.5}
+        textAnchor="middle"
+        fill="#e2e8f0"
+        fontSize={7}
+        fontWeight="600"
+        pointerEvents="none"
+      >
+        {id}
+      </text>
+      <text
+        y={0.5}
+        textAnchor="middle"
+        fill="#64748b"
+        fontSize={5.5}
+        pointerEvents="none"
+      >
+        process
+      </text>
       <rect x={-16} y={5} width={32} height={2.5} rx={1} fill="#1e293b" />
-      <rect x={-16} y={5} width={barW(id)} height={2.5} rx={1} fill={accent} opacity={0.5} />
-      <circle cx={-24} cy={0} r={3} fill="#1e293b" stroke="#475569" strokeWidth={0.75} />
-      <circle cx={24} cy={0} r={3} fill="#1e293b" stroke="#475569" strokeWidth={0.75} />
+      <rect
+        x={-16}
+        y={5}
+        width={barW(id)}
+        height={2.5}
+        rx={1}
+        fill={accent}
+        opacity={0.5}
+      />
+      <circle
+        cx={-24}
+        cy={0}
+        r={3}
+        fill="#1e293b"
+        stroke="#475569"
+        strokeWidth={0.75}
+      />
+      <circle
+        cx={24}
+        cy={0}
+        r={3}
+        fill="#1e293b"
+        stroke="#475569"
+        strokeWidth={0.75}
+      />
     </>
   );
 }
 
-// ---------------------------------------------------------------
-// Shared drag helpers
-// ---------------------------------------------------------------
-
+// Drag helpers, shared across modes.
 function useDragRefs() {
   return {
     dragging: useRef(false),
-    offset: useRef<Pos>({ x: 0, y: 0 }),
+    offset: useRef({ x: 0, y: 0 }),
   };
 }
 
 function startDrag(
-  e: React.PointerEvent,
+  e: React.PointerEvent<SVGElement>,
   nodePos: Pos,
   refs: ReturnType<typeof useDragRefs>,
 ) {
@@ -132,12 +177,18 @@ function startDrag(
   e.currentTarget.setPointerCapture(e.pointerId);
 }
 
-function endDrag(e: React.PointerEvent, refs: ReturnType<typeof useDragRefs>) {
+function endDrag(
+  e: React.PointerEvent<SVGElement>,
+  refs: ReturnType<typeof useDragRefs>,
+) {
   refs.dragging.current = false;
   e.currentTarget.releasePointerCapture(e.pointerId);
 }
 
-function dragPos(e: React.PointerEvent, refs: ReturnType<typeof useDragRefs>): Pos | null {
+function dragPos(
+  e: React.PointerEvent<SVGElement>,
+  refs: ReturnType<typeof useDragRefs>,
+): Pos | null {
   if (!refs.dragging.current) return null;
   const svg = e.currentTarget.ownerSVGElement!;
   const p = toSvg(svg, e.clientX, e.clientY);
@@ -154,14 +205,27 @@ function SigNode({ sig, id }: { sig: RefSignal<Pos>; id: number }) {
   const drag = useDragRefs();
 
   useRefSignalEffect(() => {
-    gRef.current?.setAttribute('transform', `translate(${sig.current.x},${sig.current.y})`);
+    gRef.current?.setAttribute(
+      'transform',
+      `translate(${sig.current.x},${sig.current.y})`,
+    );
   }, [sig]);
 
   return (
-    <g ref={gRef} transform={`translate(${sig.current.x},${sig.current.y})`} cursor="grab"
-      onPointerDown={(e) => startDrag(e, sig.current, drag)}
-      onPointerMove={(e) => { const p = dragPos(e, drag); if (p) sig.update(p); }}
-      onPointerUp={(e) => endDrag(e, drag)}
+    <g
+      ref={gRef}
+      transform={`translate(${sig.current.x},${sig.current.y})`}
+      cursor="grab"
+      onPointerDown={(e) => {
+        startDrag(e, sig.current, drag);
+      }}
+      onPointerMove={(e) => {
+        const p = dragPos(e, drag);
+        if (p) sig.update(p);
+      }}
+      onPointerUp={(e) => {
+        endDrag(e, drag);
+      }}
     >
       {nodeInner(id, SIG_C)}
     </g>
@@ -171,30 +235,45 @@ function SigNode({ sig, id }: { sig: RefSignal<Pos>; id: number }) {
 function SigEdge({ from, to }: { from: RefSignal<Pos>; to: RefSignal<Pos> }) {
   bumpRender();
   const ref = useRef<SVGLineElement>(null);
-  useRefSignalEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    el.setAttribute('x1', String(from.current.x));
-    el.setAttribute('y1', String(from.current.y));
-    el.setAttribute('x2', String(to.current.x));
-    el.setAttribute('y2', String(to.current.y));
-  }, [from, to], { rAF: true });
+  useRefSignalEffect(
+    () => {
+      const el = ref.current;
+      if (!el) return;
+      el.setAttribute('x1', String(from.current.x));
+      el.setAttribute('y1', String(from.current.y));
+      el.setAttribute('x2', String(to.current.x));
+      el.setAttribute('y2', String(to.current.y));
+    },
+    [from, to],
+    { rAF: true },
+  );
   return (
-    <line ref={ref}
-      x1={from.current.x} y1={from.current.y}
-      x2={to.current.x} y2={to.current.y}
-      stroke="rgba(255,255,255,0.18)" strokeWidth={1}
+    <line
+      ref={ref}
+      x1={from.current.x}
+      y1={from.current.y}
+      x2={to.current.x}
+      y2={to.current.y}
+      stroke="rgba(255,255,255,0.18)"
+      strokeWidth={1}
     />
   );
 }
 
 function SigGraph({ count }: { count: number }) {
   const { nodes, edges, w, h } = useMemo(() => generateGraph(count), [count]);
-  const sigs = useMemo(() => nodes.map((n) => createRefSignal<Pos>({ ...n })), [nodes]);
+  const sigs = useMemo(
+    () => nodes.map((n) => createRefSignal({ ...n })),
+    [nodes],
+  );
   return (
     <svg viewBox={`0 0 ${w} ${h}`} style={svgStyle}>
-      {edges.map(([a, b], i) => <SigEdge key={i} from={sigs[a]} to={sigs[b]} />)}
-      {sigs.map((s, i) => <SigNode key={i} sig={s} id={i} />)}
+      {edges.map(([a, b], i) => (
+        <SigEdge key={i} from={sigs[a]} to={sigs[b]} />
+      ))}
+      {sigs.map((s, i) => (
+        <SigNode key={i} sig={s} id={i} />
+      ))}
     </svg>
   );
 }
@@ -203,45 +282,73 @@ function SigGraph({ count }: { count: number }) {
 // 2. Jotai mode — atom per position, targeted re-renders
 // ===============================================================
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type PosAtom = any; // PrimitiveAtom<Pos> — using any to avoid version-specific type imports
 
-const JNode = memo(function JNode({ id, posAtom }: { id: number; posAtom: PosAtom }) {
+const JNode = memo(function JNode({
+  id,
+  posAtom,
+}: {
+  id: number;
+  posAtom: PosAtom;
+}) {
   bumpRender();
   const [pos, setPos] = useAtom<Pos>(posAtom);
   const drag = useDragRefs();
 
   return (
-    <g transform={`translate(${pos.x},${pos.y})`} cursor="grab"
-      onPointerDown={(e) => startDrag(e, pos, drag)}
-      onPointerMove={(e) => { const p = dragPos(e, drag); if (p) setPos(p); }}
-      onPointerUp={(e) => endDrag(e, drag)}
+    <g
+      transform={`translate(${pos.x},${pos.y})`}
+      cursor="grab"
+      onPointerDown={(e) => {
+        startDrag(e, pos, drag);
+      }}
+      onPointerMove={(e) => {
+        const p = dragPos(e, drag);
+        if (p) setPos(p);
+      }}
+      onPointerUp={(e) => {
+        endDrag(e, drag);
+      }}
     >
       {nodeInner(id, JOTAI_C)}
     </g>
   );
 });
 
-const JEdge = memo(function JEdge({ fromAtom, toAtom }: { fromAtom: PosAtom; toAtom: PosAtom }) {
+const JEdge = memo(function JEdge({
+  fromAtom,
+  toAtom,
+}: {
+  fromAtom: PosAtom;
+  toAtom: PosAtom;
+}) {
   bumpRender();
   const [from] = useAtom<Pos>(fromAtom);
   const [to] = useAtom<Pos>(toAtom);
   return (
     <line
-      x1={from.x} y1={from.y} x2={to.x} y2={to.y}
-      stroke="rgba(255,255,255,0.18)" strokeWidth={1}
+      x1={from.x}
+      y1={from.y}
+      x2={to.x}
+      y2={to.y}
+      stroke="rgba(255,255,255,0.18)"
+      strokeWidth={1}
     />
   );
 });
 
 function JGraph({ count }: { count: number }) {
   const { nodes, edges, w, h } = useMemo(() => generateGraph(count), [count]);
-  const atoms = useMemo(() => nodes.map((n) => atom<Pos>({ ...n })), [nodes]);
+  const atoms = useMemo(() => nodes.map((n) => atom({ ...n })), [nodes]);
   return (
     <JotaiProvider>
       <svg viewBox={`0 0 ${w} ${h}`} style={svgStyle}>
-        {edges.map(([a, b], i) => <JEdge key={i} fromAtom={atoms[a]} toAtom={atoms[b]} />)}
-        {atoms.map((a, i) => <JNode key={i} id={i} posAtom={a} />)}
+        {edges.map(([a, b], i) => (
+          <JEdge key={i} fromAtom={atoms[a]} toAtom={atoms[b]} />
+        ))}
+        {atoms.map((a, i) => (
+          <JNode key={i} id={i} posAtom={a} />
+        ))}
       </svg>
     </JotaiProvider>
   );
@@ -272,8 +379,12 @@ const ZNode = memo(function ZNode({ id }: { id: number }) {
   const drag = useDragRefs();
 
   return (
-    <g transform={`translate(${pos.x},${pos.y})`} cursor="grab"
-      onPointerDown={(e) => startDrag(e, pos, drag)}
+    <g
+      transform={`translate(${pos.x},${pos.y})`}
+      cursor="grab"
+      onPointerDown={(e) => {
+        startDrag(e, pos, drag);
+      }}
       onPointerMove={(e) => {
         const p = dragPos(e, drag);
         if (!p) return;
@@ -283,7 +394,9 @@ const ZNode = memo(function ZNode({ id }: { id: number }) {
           return { positions: next };
         });
       }}
-      onPointerUp={(e) => endDrag(e, drag)}
+      onPointerUp={(e) => {
+        endDrag(e, drag);
+      }}
     >
       {nodeInner(id, ZUS_C)}
     </g>
@@ -297,8 +410,12 @@ const ZEdge = memo(function ZEdge({ a, b }: { a: number; b: number }) {
   const to = store((s) => s.positions[b]);
   return (
     <line
-      x1={from.x} y1={from.y} x2={to.x} y2={to.y}
-      stroke="rgba(255,255,255,0.18)" strokeWidth={1}
+      x1={from.x}
+      y1={from.y}
+      x2={to.x}
+      y2={to.y}
+      stroke="rgba(255,255,255,0.18)"
+      strokeWidth={1}
     />
   );
 });
@@ -309,8 +426,12 @@ function ZGraph({ count }: { count: number }) {
   return (
     <ZStoreCtx.Provider value={store}>
       <svg viewBox={`0 0 ${w} ${h}`} style={svgStyle}>
-        {edges.map(([a, b], i) => <ZEdge key={i} a={a} b={b} />)}
-        {nodes.map((_, i) => <ZNode key={i} id={i} />)}
+        {edges.map(([a, b], i) => (
+          <ZEdge key={i} a={a} b={b} />
+        ))}
+        {nodes.map((_, i) => (
+          <ZNode key={i} id={i} />
+        ))}
       </svg>
     </ZStoreCtx.Provider>
   );
@@ -321,19 +442,34 @@ function ZGraph({ count }: { count: number }) {
 // ===============================================================
 
 const RNode = memo(function RNode({
-  id, pos, onDown, onMove, onUp,
+  id,
+  pos,
+  onDown,
+  onMove,
+  onUp,
 }: {
-  id: number; pos: Pos;
+  id: number;
+  pos: Pos;
   onDown: (id: number, e: React.PointerEvent) => void;
   onMove: (id: number, e: React.PointerEvent) => void;
   onUp: (id: number, e: React.PointerEvent) => void;
 }) {
   bumpRender();
   return (
-    <g transform={`translate(${pos.x},${pos.y})`} cursor="grab"
-      onPointerDown={(e) => { e.currentTarget.setPointerCapture(e.pointerId); onDown(id, e); }}
-      onPointerMove={(e) => onMove(id, e)}
-      onPointerUp={(e) => { e.currentTarget.releasePointerCapture(e.pointerId); onUp(id, e); }}
+    <g
+      transform={`translate(${pos.x},${pos.y})`}
+      cursor="grab"
+      onPointerDown={(e) => {
+        e.currentTarget.setPointerCapture(e.pointerId);
+        onDown(id, e);
+      }}
+      onPointerMove={(e) => {
+        onMove(id, e);
+      }}
+      onPointerUp={(e) => {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+        onUp(id, e);
+      }}
     >
       {nodeInner(id, REACT_C)}
     </g>
@@ -344,21 +480,33 @@ const REdge = memo(function REdge({ from, to }: { from: Pos; to: Pos }) {
   bumpRender();
   return (
     <line
-      x1={from.x} y1={from.y} x2={to.x} y2={to.y}
-      stroke="rgba(255,255,255,0.18)" strokeWidth={1}
+      x1={from.x}
+      y1={from.y}
+      x2={to.x}
+      y2={to.y}
+      stroke="rgba(255,255,255,0.18)"
+      strokeWidth={1}
     />
   );
 });
 
 function RGraph({ count }: { count: number }) {
-  const { nodes: init, edges, w, h } = useMemo(() => generateGraph(count), [count]);
+  const {
+    nodes: init,
+    edges,
+    w,
+    h,
+  } = useMemo(() => generateGraph(count), [count]);
   const [positions, setPositions] = useState(init);
   const posRef = useRef(init);
   const dragRef = useRef<number | null>(null);
-  const offsetRef = useRef<Pos>({ x: 0, y: 0 });
+  const offsetRef = useRef({ x: 0, y: 0 });
   const svgRef = useRef<SVGSVGElement>(null);
 
-  useEffect(() => { setPositions(init); posRef.current = init; }, [init]);
+  useEffect(() => {
+    setPositions(init);
+    posRef.current = init;
+  }, [init]);
 
   const onDown = useCallback((id: number, e: React.PointerEvent) => {
     dragRef.current = id;
@@ -389,18 +537,24 @@ function RGraph({ count }: { count: number }) {
 
   return (
     <svg ref={svgRef} viewBox={`0 0 ${w} ${h}`} style={svgStyle}>
-      {edges.map(([a, b], i) => <REdge key={i} from={positions[a]} to={positions[b]} />)}
+      {edges.map(([a, b], i) => (
+        <REdge key={i} from={positions[a]} to={positions[b]} />
+      ))}
       {positions.map((pos, i) => (
-        <RNode key={i} id={i} pos={pos} onDown={onDown} onMove={onMove} onUp={onUp} />
+        <RNode
+          key={i}
+          id={i}
+          pos={pos}
+          onDown={onDown}
+          onMove={onMove}
+          onUp={onUp}
+        />
       ))}
     </svg>
   );
 }
 
-// ---------------------------------------------------------------
-// Stats overlay
-// ---------------------------------------------------------------
-
+// Stats — imperative DOM writes so this panel stays out of the benchmark.
 function Stats({ mode }: { mode: string }) {
   const fpsRef = useRef<HTMLSpanElement>(null);
   const rpsRef = useRef<HTMLSpanElement>(null);
@@ -415,25 +569,34 @@ function Stats({ mode }: { mode: string }) {
     prevRendersRef.current = getRenders();
   }, [mode, frame]);
 
-  useRefSignalEffect(
-    () => {
-      if (frame.tick === 0) return;
-      framesRef.current++;
-      if (frame.elapsed - lastSampleRef.current >= 1000) {
-        const r = getRenders();
-        if (fpsRef.current) fpsRef.current.textContent = String(framesRef.current);
-        if (rpsRef.current) rpsRef.current.textContent = String(r - prevRendersRef.current);
-        framesRef.current = 0;
-        prevRendersRef.current = r;
-        lastSampleRef.current = frame.elapsed;
-      }
-    },
-    [frame],
-  );
+  useRefSignalEffect(() => {
+    if (frame.tick === 0) return;
+    framesRef.current++;
+    if (frame.elapsed - lastSampleRef.current >= 1000) {
+      const r = getRenders();
+      if (fpsRef.current)
+        fpsRef.current.textContent = String(framesRef.current);
+      if (rpsRef.current)
+        rpsRef.current.textContent = String(r - prevRendersRef.current);
+      framesRef.current = 0;
+      prevRendersRef.current = r;
+      lastSampleRef.current = frame.elapsed;
+    }
+  }, [frame]);
   return (
     <>
-      <span style={statBadge}>FPS <b ref={fpsRef} style={{ minWidth: 28, display: 'inline-block' }}>--</b></span>
-      <span style={statBadge}>renders/s <b ref={rpsRef} style={{ minWidth: 36, display: 'inline-block' }}>--</b></span>
+      <span style={statBadge}>
+        FPS{' '}
+        <b ref={fpsRef} style={{ minWidth: 28, display: 'inline-block' }}>
+          --
+        </b>
+      </span>
+      <span style={statBadge}>
+        renders/s{' '}
+        <b ref={rpsRef} style={{ minWidth: 36, display: 'inline-block' }}>
+          --
+        </b>
+      </span>
     </>
   );
 }
@@ -442,17 +605,32 @@ function Stats({ mode }: { mode: string }) {
 // Styles
 // ---------------------------------------------------------------
 
-const svgStyle: React.CSSProperties = { width: '100%', height: '100%', display: 'block' };
+const svgStyle: React.CSSProperties = {
+  width: '100%',
+  height: '100%',
+  display: 'block',
+};
 
 const statBadge: React.CSSProperties = {
-  background: '#0d1117', padding: '4px 10px', borderRadius: 4, fontSize: 13, fontFamily: 'monospace',
+  background: '#0d1117',
+  padding: '4px 10px',
+  borderRadius: 4,
+  fontSize: 13,
+  fontFamily: 'monospace',
 };
 
 function btnStyle(active: boolean, color: string): React.CSSProperties {
   return {
-    padding: '5px 14px', border: 'none', borderRadius: 6, cursor: 'pointer',
-    fontWeight: 600, fontSize: 12, background: active ? color : '#333',
-    color: '#fff', opacity: active ? 1 : 0.6, transition: 'opacity 0.15s',
+    padding: '5px 14px',
+    border: 'none',
+    borderRadius: 6,
+    cursor: 'pointer',
+    fontWeight: 600,
+    fontSize: 12,
+    background: active ? color : '#333',
+    color: '#fff',
+    opacity: active ? 1 : 0.6,
+    transition: 'opacity 0.15s',
   };
 }
 
@@ -462,12 +640,29 @@ function btnStyle(active: boolean, color: string): React.CSSProperties {
 
 type Mode = 'signal' | 'jotai' | 'zustand' | 'react';
 
-const MODE_META: Record<Mode, { color: string; label: string; hint: string }> = {
-  signal:  { color: SIG_C,   label: 'RefSignal',          hint: 'Zero re-renders — DOM updated directly via effects' },
-  jotai:   { color: JOTAI_C, label: 'Jotai (atoms)',      hint: 'Atom-per-position — only changed node + edges re-render' },
-  zustand: { color: ZUS_C,   label: 'Zustand (selectors)', hint: 'Individual selectors — all 16k+ selectors run per frame' },
-  react:   { color: REACT_C, label: 'React + memo',       hint: 'Parent-driven state — parent re-renders entire subtree each frame' },
-};
+const MODE_META: Record<Mode, { color: string; label: string; hint: string }> =
+  {
+    signal: {
+      color: SIG_C,
+      label: 'RefSignal',
+      hint: 'Zero re-renders — DOM updated directly via effects',
+    },
+    jotai: {
+      color: JOTAI_C,
+      label: 'Jotai (atoms)',
+      hint: 'Atom-per-position — only changed node + edges re-render',
+    },
+    zustand: {
+      color: ZUS_C,
+      label: 'Zustand (selectors)',
+      hint: 'Individual selectors — all 16k+ selectors run per frame',
+    },
+    react: {
+      color: REACT_C,
+      label: 'React + memo',
+      hint: 'Parent-driven state — parent re-renders entire subtree each frame',
+    },
+  };
 
 function countEdges(n: number): number {
   const cols = Math.ceil(Math.sqrt(n));
@@ -488,29 +683,66 @@ export default function GraphBenchmark() {
   const edges = useMemo(() => countEdges(count), [count]);
   const meta = MODE_META[mode];
 
-  const switchMode = (m: Mode) => { resetRenders(); setMode(m); };
+  const switchMode = (m: Mode) => {
+    resetRenders();
+    setMode(m);
+  };
 
   return (
-    <div style={{
-      background: '#1a1a2e', color: '#fff', height: '100vh',
-      display: 'flex', flexDirection: 'column',
-      fontFamily: 'system-ui, sans-serif', userSelect: 'none',
-    }}>
+    <div
+      style={{
+        background: '#1a1a2e',
+        color: '#fff',
+        height: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        fontFamily: 'system-ui, sans-serif',
+        userSelect: 'none',
+      }}
+    >
       {/* toolbar */}
-      <div style={{
-        display: 'flex', alignItems: 'center', gap: 8,
-        padding: '8px 14px', background: '#16213e', flexWrap: 'wrap',
-      }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '8px 14px',
+          background: '#16213e',
+          flexWrap: 'wrap',
+        }}
+      >
         {(Object.keys(MODE_META) as Mode[]).map((m) => (
-          <button key={m} onClick={() => switchMode(m)} style={btnStyle(mode === m, MODE_META[m].color)}>
+          <button
+            key={m}
+            onClick={() => {
+              switchMode(m);
+            }}
+            style={btnStyle(mode === m, MODE_META[m].color)}
+          >
             {MODE_META[m].label}
           </button>
         ))}
 
-        <label style={{ display: 'flex', alignItems: 'center', gap: 6, marginLeft: 8, fontSize: 12 }}>
+        <label
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            marginLeft: 8,
+            fontSize: 12,
+          }}
+        >
           Nodes
-          <input type="range" min={9} max={2000} value={count}
-            onChange={(e) => { resetRenders(); setCount(+e.target.value); }} />
+          <input
+            type="range"
+            min={9}
+            max={2000}
+            value={count}
+            onChange={(e) => {
+              resetRenders();
+              setCount(+e.target.value);
+            }}
+          />
         </label>
 
         <span style={{ fontSize: 11, opacity: 0.5, fontFamily: 'monospace' }}>
@@ -523,19 +755,24 @@ export default function GraphBenchmark() {
       </div>
 
       {/* hint */}
-      <div style={{
-        padding: '3px 14px', fontSize: 11, opacity: 0.4,
-        background: '#16213e', borderTop: '1px solid #1a1a2e',
-      }}>
+      <div
+        style={{
+          padding: '3px 14px',
+          fontSize: 11,
+          opacity: 0.4,
+          background: '#16213e',
+          borderTop: '1px solid #1a1a2e',
+        }}
+      >
         {meta.hint}
       </div>
 
       {/* graph */}
       <div style={{ flex: 1, overflow: 'hidden', padding: 8 }}>
-        {mode === 'signal'  && <SigGraph key={`s-${count}`} count={count} />}
-        {mode === 'jotai'   && <JGraph key={`j-${count}`} count={count} />}
+        {mode === 'signal' && <SigGraph key={`s-${count}`} count={count} />}
+        {mode === 'jotai' && <JGraph key={`j-${count}`} count={count} />}
         {mode === 'zustand' && <ZGraph key={`z-${count}`} count={count} />}
-        {mode === 'react'   && <RGraph key={`r-${count}`} count={count} />}
+        {mode === 'react' && <RGraph key={`r-${count}`} count={count} />}
       </div>
     </div>
   );

--- a/demo/heartbeat.tsx
+++ b/demo/heartbeat.tsx
@@ -1,0 +1,186 @@
+// Heartbeat — pulse rate driven by mouse distance.
+//
+// The circle pulses faster as the cursor gets closer, slower as it moves away.
+// Cadence flows through the reactive graph: mouse position → derived rate
+// signal → `updatePulse(rate.current)`. No setInterval, no useEffect timers.
+
+import { useEffect, useRef } from 'react';
+import {
+  usePulseRefSignal,
+  useRefSignal,
+  useRefSignalEffect,
+  useRefSignalMemo,
+  useRefSignalRender,
+  type PulseRate,
+} from 'react-refsignal';
+
+const MIN_MS = 200;
+const MAX_MS = 2000;
+const FAR_PX = 600;
+
+// Distance → ms interval. Linear ramp clamped to [MIN_MS, MAX_MS].
+function rateFromDistance(d: number): PulseRate {
+  const t = Math.min(1, d / FAR_PX);
+  const ms = Math.round(MIN_MS + t * (MAX_MS - MIN_MS));
+  return `${String(ms)}ms` as PulseRate;
+}
+
+export default function Heartbeat() {
+  const mouse = useRefSignal({ x: 0, y: 0 });
+  const circleRef = useRef<HTMLDivElement>(null);
+  const center = useRef({ x: 0, y: 0 });
+
+  // Initial cadence is the resting rate; updatePulse below wires it to the
+  // computed `heartRate` so cadence becomes reactive data.
+  const heart = usePulseRefSignal(`${String(MAX_MS)}ms` as PulseRate);
+
+  // Derived rate: mouse-to-circle distance → ms interval.
+  const heartRate = useRefSignalMemo(() => {
+    const dx = mouse.current.x - center.current.x;
+    const dy = mouse.current.y - center.current.y;
+    return rateFromDistance(Math.hypot(dx, dy));
+  }, [mouse]);
+
+  // On each tick: bump animation that fills the full beat, then adapt the rate
+  // for the NEXT beat. Animation duration uses `heartRate.current` (not
+  // `heart.dt`) — same value we pass to `updatePulse`, so the animation ends
+  // exactly when the next tick fires. Using `heart.dt` would be the old rate,
+  // mismatching the new interval and causing flicker across rate changes.
+  useRefSignalEffect(() => {
+    const el = circleRef.current;
+    if (!el) return;
+    const interval = parseInt(String(heartRate.current), 10);
+    el.animate(
+      [
+        { transform: 'scale(1) translateY(0)' },
+        { transform: 'scale(1.35) translateY(-10px)', offset: 0.2 },
+        { transform: 'scale(1) translateY(0)' },
+      ],
+      { duration: interval, easing: 'ease-out' },
+    );
+    heart.updatePulse(heartRate.current);
+  }, [heart]);
+
+  // Badge re-renders on rate change. rAF coalesces the mousemove fan-out.
+  useRefSignalRender([heartRate], { rAF: true });
+
+  // Mouse tracking.
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      mouse.update({ x: e.clientX, y: e.clientY });
+    };
+    window.addEventListener('mousemove', onMove);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+    };
+  }, [mouse]);
+
+  // Measure circle center on mount + resize.
+  useEffect(() => {
+    const measure = () => {
+      const el = circleRef.current;
+      if (!el) return;
+      const r = el.getBoundingClientRect();
+      center.current = { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+    };
+    measure();
+    window.addEventListener('resize', measure);
+    return () => {
+      window.removeEventListener('resize', measure);
+    };
+  }, []);
+
+  // heartRate is always 'Nms' here (rateFromDistance only emits that form).
+  const intervalMs = parseInt(String(heartRate.current), 10);
+  const bpm = Math.round(60000 / intervalMs);
+
+  return (
+    <div style={pageStyle}>
+      <div
+        ref={circleRef}
+        style={{
+          width: 140,
+          height: 140,
+          borderRadius: '50%',
+          background:
+            'radial-gradient(circle at 35% 30%, #ff7b8b, #c92a3a 60%, #7a0a16)',
+          boxShadow:
+            '0 0 60px rgba(255, 107, 107, 0.45), inset 0 0 30px rgba(0,0,0,0.2)',
+          willChange: 'transform',
+        }}
+      />
+
+      <div style={infoBlock}>
+        <div style={bpmStyle}>{bpm} bpm</div>
+        <div style={hintStyle}>
+          Move closer to make the heart race; further away to calm it down.
+        </div>
+      </div>
+
+      <div style={legendStyle}>
+        <code style={codeStyle}>useRefSignalMemo</code> derives a{' '}
+        <code style={codeStyle}>PulseRate</code> from the mouse signal;{' '}
+        <code style={codeStyle}>useRefSignalEffect</code> calls{' '}
+        <code style={codeStyle}>heart.updatePulse(heartRate.current)</code>.
+        Cadence is data — it flows through the reactive graph.
+      </div>
+    </div>
+  );
+}
+
+const pageStyle: React.CSSProperties = {
+  background:
+    'radial-gradient(ellipse at center, #2a1020 0%, #0d0716 70%, #06030f 100%)',
+  color: '#fff',
+  height: '100vh',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexDirection: 'column',
+  gap: 28,
+  fontFamily: 'system-ui, sans-serif',
+  padding: 24,
+};
+
+const infoBlock: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: 8,
+};
+
+const bpmStyle: React.CSSProperties = {
+  fontFamily: 'monospace',
+  fontSize: 32,
+  fontWeight: 700,
+  letterSpacing: 1,
+  color: '#ff8a9c',
+  textShadow: '0 0 20px rgba(255, 107, 107, 0.5)',
+};
+
+const hintStyle: React.CSSProperties = {
+  fontSize: 13,
+  opacity: 0.7,
+  maxWidth: 320,
+  textAlign: 'center',
+};
+
+const legendStyle: React.CSSProperties = {
+  position: 'fixed',
+  bottom: 64,
+  left: '50%',
+  transform: 'translateX(-50%)',
+  fontSize: 12,
+  opacity: 0.55,
+  maxWidth: 540,
+  textAlign: 'center',
+  lineHeight: 1.6,
+};
+
+const codeStyle: React.CSSProperties = {
+  padding: '1px 6px',
+  borderRadius: 3,
+  fontFamily: 'monospace',
+  fontSize: 11,
+  background: 'rgba(255,255,255,0.1)',
+};

--- a/demo/main.tsx
+++ b/demo/main.tsx
@@ -4,15 +4,17 @@ import GraphBenchmark from './graph-benchmark';
 import ThemeDemo from './theme-demo';
 import GameOfLife from './game-of-life';
 import Agents from './agents';
+import Heartbeat from './heartbeat';
 
-// StrictMode removed for clean benchmark numbers (it double-renders in dev).
+// No StrictMode — its dev-mode double renders skew benchmark numbers.
 
-type Route = 'graph' | 'theme' | 'gol' | 'agents';
+type Route = 'graph' | 'theme' | 'gol' | 'agents' | 'heart';
 
 function parseRoute(): Route {
   if (window.location.hash === '#theme') return 'theme';
   if (window.location.hash === '#gol') return 'gol';
   if (window.location.hash === '#agents') return 'agents';
+  if (window.location.hash === '#heart') return 'heart';
   return 'graph';
 }
 
@@ -60,11 +62,15 @@ function Demos() {
         <a href="#agents" style={navBtn(route === 'agents')}>
           Agents
         </a>
+        <a href="#heart" style={navBtn(route === 'heart')}>
+          Heartbeat (pulse)
+        </a>
       </nav>
       {route === 'graph' && <GraphBenchmark />}
       {route === 'theme' && <ThemeDemo />}
       {route === 'gol' && <GameOfLife />}
       {route === 'agents' && <Agents />}
+      {route === 'heart' && <Heartbeat />}
     </>
   );
 }

--- a/demo/theme-demo.tsx
+++ b/demo/theme-demo.tsx
@@ -1,13 +1,5 @@
-// demo/theme-demo.tsx
-//
-// Persist + Broadcast composed on the same store.
-//
-// Try it:
-//   - Pick colors. They're saved to localStorage (persist).
-//   - Open the same URL in a second tab. Same colors apply — cross-tab sync
-//     via BroadcastChannel (broadcast).
-//   - Change colors in either tab. The other updates live.
-//   - Reload any tab. Colors restored from localStorage.
+// Persist + Broadcast composed on the same store. Open in two tabs to see
+// live cross-tab sync; reload to see hydration from localStorage.
 
 import {
   batch,
@@ -21,11 +13,7 @@ import {
 import { broadcast, useBroadcast } from 'react-refsignal/broadcast';
 import { persist } from 'react-refsignal/persist';
 
-// ---------------------------------------------------------------
-// Store — factory wrapped by persist and broadcast.
-// Order matters: `broadcast` wraps `persist` wraps the factory.
-// ---------------------------------------------------------------
-
+// Order matters: broadcast wraps persist wraps the factory.
 type ThemeStore = {
   bg: RefSignal<string>;
   fg: RefSignal<string>;
@@ -46,47 +34,32 @@ const themeStore = createRefSignalStore<ThemeStore>(
   ),
 );
 
-// ---------------------------------------------------------------
-// Broadcaster-mode store — one-to-many election demo.
-// This store has NO persist and NO outer broadcast wrapper — the
-// `useBroadcast` hook attaches cross-tab sync at the component level
-// so we can observe the `isBroadcaster` signal in the UI.
-// ---------------------------------------------------------------
-
+// One-to-many election demo. No store-level enhancers — `useBroadcast`
+// attaches sync at the component so we can observe `isBroadcaster` in the UI.
 type StatusStore = { message: RefSignal<string> };
 
 const statusStore = createRefSignalStore<StatusStore>(() => ({
   message: createRefSignal(''),
 }));
 
-// ---------------------------------------------------------------
-// Presets
-// ---------------------------------------------------------------
-
 const PRESETS: { name: string; bg: string; fg: string; accent: string }[] = [
   { name: 'Midnight', bg: '#1a1a2e', fg: '#e2e8f0', accent: '#4a9eff' },
-  { name: 'Paper',    bg: '#fafaf5', fg: '#1a1a1a', accent: '#d97706' },
-  { name: 'Forest',   bg: '#0f1f17', fg: '#d8e6d0', accent: '#6ee7b7' },
-  { name: 'Solarized',bg: '#002b36', fg: '#eee8d5', accent: '#b58900' },
-  { name: 'Rose',     bg: '#2d1b2d', fg: '#fbcfe8', accent: '#f472b6' },
+  { name: 'Paper', bg: '#fafaf5', fg: '#1a1a1a', accent: '#d97706' },
+  { name: 'Forest', bg: '#0f1f17', fg: '#d8e6d0', accent: '#6ee7b7' },
+  { name: 'Solarized', bg: '#002b36', fg: '#eee8d5', accent: '#b58900' },
+  { name: 'Rose', bg: '#2d1b2d', fg: '#fbcfe8', accent: '#f472b6' },
   { name: 'Highlighter', bg: '#fff9c4', fg: '#1a1a1a', accent: '#f97316' },
 ];
 
-// ---------------------------------------------------------------
-// UI
-// ---------------------------------------------------------------
-
 export default function ThemeDemo() {
-  // Re-render when any of the three signals change. Unwrap for plain-value
-  // reads + auto-generated setters (setBg, setFg, setAccent).
+  // Unwrap = plain values + auto-generated setters (setBg, setFg, setAccent).
   const store = useRefSignalStore(themeStore, {
     renderOn: ['bg', 'fg', 'accent'],
     unwrap: true,
   });
   const { bg, fg, accent, setBg, setFg, setAccent } = store;
 
-  // One-to-many broadcaster election for the status message.
-  // `isBroadcaster` is a signal — the UI re-renders on its transition.
+  // `isBroadcaster` is a signal; the UI re-renders on its transition.
   const { isBroadcaster } = useBroadcast(statusStore, {
     channel: 'refsignal-status',
     mode: 'one-to-many',
@@ -100,52 +73,53 @@ export default function ThemeDemo() {
     unwrap: true,
   });
 
-  // Apply colors to <body> imperatively — no React in the "paint" path.
-  // The effect re-runs on any of the three signals firing.
+  // Apply colors to <body> imperatively — no React in the paint path.
   useRefSignalEffect(() => {
     document.body.style.background = themeStore.bg.current;
     document.body.style.color = themeStore.fg.current;
   }, [themeStore.bg, themeStore.fg]);
 
   return (
-    <div style={{
-      minHeight: '100vh',
-      padding: '40px 24px',
-      display: 'flex',
-      flexDirection: 'column',
-      gap: 24,
-      fontFamily: 'system-ui, sans-serif',
-    }}>
+    <div
+      style={{
+        minHeight: '100vh',
+        padding: '40px 24px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 24,
+        fontFamily: 'system-ui, sans-serif',
+      }}
+    >
       <header>
         <h1 style={{ margin: 0, fontSize: 28, color: accent }}>
           refsignal theme sync
         </h1>
         <p style={{ marginTop: 8, opacity: 0.75, fontSize: 14, maxWidth: 680 }}>
-          Colors are stored via <b style={{ color: accent }}>persist</b> (localStorage)
-          and synced via <b style={{ color: accent }}>broadcast</b> (BroadcastChannel).
-          Open this page in a second tab to see live sync — and reload either tab
-          to see hydration from storage.
+          Colors are stored via <b style={{ color: accent }}>persist</b>{' '}
+          (localStorage) and synced via{' '}
+          <b style={{ color: accent }}>broadcast</b> (BroadcastChannel). Open
+          this page in a second tab to see live sync — and reload either tab to
+          see hydration from storage.
         </p>
       </header>
 
       <section style={{ display: 'flex', gap: 24, flexWrap: 'wrap' }}>
         <ColorField label="Background" value={bg} onChange={setBg} />
-        <ColorField label="Text"       value={fg} onChange={setFg} />
-        <ColorField label="Accent"     value={accent} onChange={setAccent} />
+        <ColorField label="Text" value={fg} onChange={setFg} />
+        <ColorField label="Accent" value={accent} onChange={setAccent} />
       </section>
 
       <section>
-        <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>Presets</div>
+        <div style={{ fontSize: 12, opacity: 0.6, marginBottom: 8 }}>
+          Presets
+        </div>
         <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
           {PRESETS.map((p) => (
             <button
               key={p.name}
               onClick={() => {
-                // batch() coalesces the three signal updates into one
-                // notification burst. Without it, each .update() would fire
-                // broadcast separately — three partial snapshots flying
-                // across tabs would echo-and-revert each other because the
-                // second tab's echoes arrive after local state has moved on.
+                // batch() — without it, three partial snapshots fly across
+                // tabs and echo-and-revert each other.
                 batch(() => {
                   setBg(p.bg);
                   setFg(p.fg);
@@ -171,38 +145,51 @@ export default function ThemeDemo() {
         </Badge>
       </section>
 
-      <section style={{
-        marginTop: 12,
-        padding: 16,
-        borderRadius: 8,
-        border: `1px solid ${accent}44`,
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 10,
-      }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' }}>
+      <section
+        style={{
+          marginTop: 12,
+          padding: 16,
+          borderRadius: 8,
+          border: `1px solid ${accent}44`,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 10,
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            flexWrap: 'wrap',
+          }}
+        >
           <h2 style={{ margin: 0, fontSize: 16 }}>Broadcaster mode</h2>
           <code style={codeStyle}>mode: &apos;one-to-many&apos;</code>
           {isBroadcaster.current ? (
-            <span style={{
-              padding: '4px 10px',
-              borderRadius: 999,
-              background: accent,
-              color: bg,
-              fontSize: 12,
-              fontWeight: 700,
-            }}>
+            <span
+              style={{
+                padding: '4px 10px',
+                borderRadius: 999,
+                background: accent,
+                color: bg,
+                fontSize: 12,
+                fontWeight: 700,
+              }}
+            >
               📣 This tab is broadcasting
             </span>
           ) : (
-            <span style={{
-              padding: '4px 10px',
-              borderRadius: 999,
-              background: 'rgba(255,255,255,0.08)',
-              fontSize: 12,
-              fontWeight: 700,
-              opacity: 0.7,
-            }}>
+            <span
+              style={{
+                padding: '4px 10px',
+                borderRadius: 999,
+                background: 'rgba(255,255,255,0.08)',
+                fontSize: 12,
+                fontWeight: 700,
+                opacity: 0.7,
+              }}
+            >
               👂 Listening — read-only
             </span>
           )}
@@ -222,7 +209,9 @@ export default function ThemeDemo() {
               ? 'Type a status message — other tabs will see it live'
               : 'Only the broadcaster can edit — promote this tab by closing the broadcaster'
           }
-          onChange={(e) => setMessage(e.target.value)}
+          onChange={(e) => {
+            setMessage(e.target.value);
+          }}
           disabled={!isBroadcaster.current}
           style={{
             padding: '10px 14px',
@@ -237,25 +226,23 @@ export default function ThemeDemo() {
         />
       </section>
 
-      <footer style={{
-        marginTop: 'auto',
-        fontSize: 12,
-        opacity: 0.5,
-        borderTop: `1px solid ${accent}33`,
-        paddingTop: 12,
-      }}>
-        See <code style={codeStyle}>demo/theme-demo.tsx</code> — the whole app is
-        ~1 <code style={codeStyle}>createRefSignalStore</code> wrapped by{' '}
+      <footer
+        style={{
+          marginTop: 'auto',
+          fontSize: 12,
+          opacity: 0.5,
+          borderTop: `1px solid ${accent}33`,
+          paddingTop: 12,
+        }}
+      >
+        See <code style={codeStyle}>demo/theme-demo.tsx</code> — the whole app
+        is ~1 <code style={codeStyle}>createRefSignalStore</code> wrapped by{' '}
         <code style={codeStyle}>broadcast()</code> and{' '}
         <code style={codeStyle}>persist()</code>.
       </footer>
     </div>
   );
 }
-
-// ---------------------------------------------------------------
-// Sub-components
-// ---------------------------------------------------------------
 
 function ColorField({
   label,
@@ -273,13 +260,24 @@ function ColorField({
         <input
           type="color"
           value={value}
-          onChange={(e) => onChange(e.target.value)}
-          style={{ width: 42, height: 32, padding: 0, border: 'none', background: 'transparent', cursor: 'pointer' }}
+          onChange={(e) => {
+            onChange(e.target.value);
+          }}
+          style={{
+            width: 42,
+            height: 32,
+            padding: 0,
+            border: 'none',
+            background: 'transparent',
+            cursor: 'pointer',
+          }}
         />
         <input
           type="text"
           value={value}
-          onChange={(e) => onChange(e.target.value)}
+          onChange={(e) => {
+            onChange(e.target.value);
+          }}
           style={{
             padding: '6px 10px',
             fontFamily: 'monospace',
@@ -298,16 +296,18 @@ function ColorField({
 
 function Badge({ children }: { children: React.ReactNode }) {
   return (
-    <div style={{
-      padding: '8px 14px',
-      borderRadius: 6,
-      background: 'rgba(255,255,255,0.06)',
-      border: '1px solid rgba(255,255,255,0.1)',
-      fontSize: 13,
-      display: 'flex',
-      alignItems: 'center',
-      gap: 6,
-    }}>
+    <div
+      style={{
+        padding: '8px 14px',
+        borderRadius: 6,
+        background: 'rgba(255,255,255,0.06)',
+        border: '1px solid rgba(255,255,255,0.1)',
+        fontSize: 13,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 6,
+      }}
+    >
       {children}
     </div>
   );
@@ -321,7 +321,11 @@ const codeStyle: React.CSSProperties = {
   background: 'rgba(255,255,255,0.1)',
 };
 
-function presetBtn(bg: string, fg: string, accent: string): React.CSSProperties {
+function presetBtn(
+  bg: string,
+  fg: string,
+  accent: string,
+): React.CSSProperties {
   return {
     padding: '10px 16px',
     border: `2px solid ${accent}`,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -104,4 +104,24 @@ export default tseslint.config(
       'react/display-name': 'off',
     },
   },
+
+  // ── Demo files: relax rules for application-style code ──────────────────────
+  // Demos use DOM-known-non-null asserts, numbers in SVG template literals,
+  // void-returning arrow shorthands in event handlers, and other patterns
+  // that aren't load-bearing for library correctness.
+  {
+    files: ['demo/**/*.{ts,tsx}'],
+    rules: {
+      '@typescript-eslint/no-non-null-assertion': 'off',
+      '@typescript-eslint/restrict-template-expressions': 'off',
+      '@typescript-eslint/no-confusing-void-expression': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+      'react-hooks/set-state-in-effect': 'off',
+    },
+  },
 )

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -121,6 +121,7 @@ export default tseslint.config(
       '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/no-unsafe-return': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-redundant-type-constituents': 'off',
       'react-hooks/set-state-in-effect': 'off',
     },
   },

--- a/package.json
+++ b/package.json
@@ -30,9 +30,10 @@
     "test": "jest",
     "coverage": "jest --coverage",
     "typecheck": "tsc --noEmit",
-    "typecheck:all": "tsc --noEmit -p tsconfig.eslint.json",
-    "lint": "eslint 'src/**/*.{ts,tsx}'",
-    "lint:fix": "eslint 'src/**/*.{ts,tsx}' --fix",
+    "typecheck:demo": "tsc --noEmit -p demo/tsconfig.json",
+    "typecheck:all": "npm run typecheck && npm run typecheck:demo",
+    "lint": "eslint 'src/**/*.{ts,tsx}' 'demo/**/*.{ts,tsx}'",
+    "lint:fix": "eslint 'src/**/*.{ts,tsx}' 'demo/**/*.{ts,tsx}' --fix",
     "prettier:fix": "prettier --write 'src/**/*.{ts,tsx}'",
     "prepublishOnly": "npm run typecheck && npm run build",
     "size": "size-limit"

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -3,8 +3,14 @@
   "compilerOptions": {
     "noEmit": true,
     "noUnusedLocals": false,
-    "noUnusedParameters": false
+    "noUnusedParameters": false,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "paths": {
+      "react-refsignal": ["./src/index.ts"],
+      "react-refsignal/persist": ["./src/persist/index.ts"],
+      "react-refsignal/broadcast": ["./src/broadcast/index.ts"]
+    }
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src", "demo"],
+  "exclude": ["node_modules", "dist", "demo/dist", "demo/node_modules"]
 }


### PR DESCRIPTION
## Summary
- New **Heartbeat** demo (\`demo/heartbeat.tsx\`) showcasing pulse + \`updatePulse\` — circle beats faster as the cursor approaches; rate is data flowing through the reactive graph
- Refactor \`demo/agents.tsx\`: extract \`distSq\`, \`dominates\`, \`steerAndMove\`, \`eatPairs\` (eliminates the 25-line player/AI control duplicate and several smaller ones)
- Refactor \`demo/fps.tsx\`: \`watch\` → \`useRefSignalEffect\`, optional \`src\` pulse on \`useFps\` / \`<FpsBadge />\`
- Trim verbose comments across all demo files
- Wire demo lint + typecheck into the build:
  - \`tsconfig.eslint.json\` covers \`demo/\` with path mappings for \`react-refsignal\`
  - \`package.json\`: \`lint\` includes demo glob; new \`typecheck:demo\` and updated \`typecheck:all\`
  - \`eslint.config.mjs\`: demo-specific rule relaxations (similar to existing test-files block)
- Fix the TS errors that surfaced in \`demo/graph-benchmark.tsx\` once demo was typechecked

## Test plan
- [x] \`npm run lint\` clean
- [x] \`npm run typecheck:all\` clean (src + demo)
- [x] \`npm test\` (524/524)
- [x] \`npm run build\` clean
- [x] \`cd demo && vite build\` clean
- [x] Heartbeat: rate adapts smoothly across mouse motion, no flicker on rate transitions, no idle gaps at slow BPM