### PR TITLE
feat(broadcast): gracePeriod + isStableBroadcaster

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -927,6 +927,8 @@ useBroadcast(store, { channel: 'game', throttle: 100 });
 
 `BroadcastOptions` and `BroadcastSignalOptions` accept the same timing fields as `EffectOptions` (`throttle`, `debounce`, `maxWait`, `frame`) plus broadcast-specific fields. See the [full reference](broadcast.md#api-reference).
 
+`useBroadcast` returns `{ isBroadcaster, isStableBroadcaster }` (both `ReadonlyRefSignal<boolean>`). With the opt-in `gracePeriod` option, `isStableBroadcaster` flips `true` only after the grace window elapses since gaining leadership — useful for gating work that shouldn't fire during election ambiguity, e.g. `skip: !isStableBroadcaster.current` on a query hook. The same option also extends emit privileges for a former broadcaster within the window so in-flight work propagates instead of being silently dropped. See [Smoothing leadership transitions](broadcast.md#smoothing-leadership-transitions--graceperiod).
+
 ---
 
 ### Persist

--- a/docs/broadcast.md
+++ b/docs/broadcast.md
@@ -209,6 +209,25 @@ Set `initialElectionDelay: 0` to elect synchronously if you know the tab is alwa
 
 Non-broadcaster tabs still receive incoming updates — they just don't send any.
 
+#### Smoothing leadership transitions — `gracePeriod`
+
+Opt-in window that handles two problems at leadership transitions:
+
+1. **Trailing-emit grace.** A former broadcaster retains emit privileges for `gracePeriod` ms after losing leadership. In-flight work that fires `update()` within this window still propagates to other tabs rather than being silently dropped on the floor.
+2. **Delayed `isStableBroadcaster`.** `useBroadcast` returns a second signal — `isStableBroadcaster` — that flips `true` only after `gracePeriod` ms have elapsed since gaining leadership. Useful for gating work that shouldn't fire during election ambiguity (a fresh leader's first poll, an exclusive write, etc.).
+
+```ts
+const { isBroadcaster, isStableBroadcaster } = useBroadcast(store, {
+  channel: 'metric-poll',
+  mode: 'one-to-many',
+  gracePeriod: 5000,
+});
+```
+
+The delayed flip is **skipped when this tab is alone at election time** (no observed peers) — single-tab initial loads activate `isStableBroadcaster` synchronously with `isBroadcaster`, no useless wait. Grace only applies when there's an actual contested transition to ride out.
+
+Without `gracePeriod` (default): `isStableBroadcaster` always tracks `isBroadcaster` exactly. No trailing emits.
+
 #### Restricting localStorage writes to the leader tab
 
 When `persist` and `broadcast` are combined in `one-to-many` mode, all tabs write to storage by default (each tab reacts to the broadcast update and persists it). If you want only the leader to write, use `useBroadcast`'s `isBroadcaster` signal as the `filter` for `usePersist`:
@@ -230,6 +249,63 @@ function GameProvider({ children }: { children: ReactNode }) {
   return <GameContext.Provider value={store}>{children}</GameContext.Provider>;
 }
 ```
+
+#### Polling under broadcast — preventing fetch-flicker on tab switch
+
+A common pattern: only the elected tab polls an API, but as users switch tabs, leadership changes. Without precaution, each new leader fires a fresh request on transition — a "flicker" of redundant network calls.
+
+Compose `gracePeriod` with a broadcast-shared `lastCompletedAt` so the polling cadence is shared across tabs:
+
+```tsx
+function LeaderPoller() {
+  const store = useMemo(() => ({
+    data:            createRefSignal<Result | null>(null),
+    lastCompletedAt: createRefSignal(0),
+  }), []);
+
+  const { isStableBroadcaster } = useBroadcast(store, {
+    channel: 'metric-poll',
+    mode: 'one-to-many',
+    gracePeriod: 5000,
+  });
+
+  // Use the LAZY variant. The non-lazy `useGetMetricQuery(args, { skip })`
+  // auto-fires when `skip` flips false — that would bypass our cadence gate
+  // and cause a fresh request every time a new tab inherits leadership.
+  // Lazy returns an imperative `trigger`; the cadence effect decides when.
+  const [trigger, { data, fulfilledTimeStamp }] = useLazyGetMetricQuery();
+
+  // Mirror RTK results into shared signals (only the tab that triggered
+  // the fetch sees `data` change from this hook).
+  useEffect(() => {
+    if (fulfilledTimeStamp) store.lastCompletedAt.update(fulfilledTimeStamp);
+    if (data) store.data.update(data);
+  }, [fulfilledTimeStamp, data]);
+
+  // Cadence: only fire if the shared lastCompletedAt is older than the
+  // interval. Gated on isStableBroadcaster — leadership churn doesn't fire
+  // anything, the threshold against shared lastCompletedAt is the only gate.
+  const tick = usePulseRefSignal('500ms');
+  useRefSignalEffect(() => {
+    if (!isStableBroadcaster.current) return;
+    if (Date.now() - store.lastCompletedAt.current < 5000) return;
+    void trigger(undefined);
+  }, [tick, isStableBroadcaster, store.lastCompletedAt, trigger]);
+
+  return <DataView data={store.data} />;
+}
+```
+
+What composes here:
+
+- **Cadence preserved across tab switches.** With the lazy variant, only the cadence effect fires a request. When a new tab inherits leadership mid-cycle, its check `Date.now() - lastCompletedAt < 5000` skips until the threshold is genuinely met. A user rapidly switching between tabs never triggers a fresh request — the global "5 s between polls" invariant holds.
+- **Single network cost per cycle**, even across leadership churn.
+- **Single-tab loads activate instantly** — alone at election time, `isStableBroadcaster` flips synchronously, no 5 s wait before the first poll.
+- **Trailing-emit grace earns its keep.** If a former leader's lazy query was in flight when leadership flipped, the response landing within `gracePeriod` ms still writes to `store.data` and propagates across tabs (the emit gate accepts the write). Other tabs see fresh data without anyone making a second request.
+
+**`isStableBroadcaster` semantics are asymmetric on purpose**: true-flip is delayed by `gracePeriod` (settle before starting work), false-flip is synchronous (stop scheduling new work the moment leadership is lost). The synchronous false-flip stops the cadence effect from firing on a non-leader; in-flight lazy-query promises are *not* automatically aborted — that's why trailing-emit grace works. If you want to abort, capture the trigger's returned promise and call `.abort()` from a separate effect watching leadership loss.
+
+**Why not the non-lazy `useGetMetricQuery` + `skip` pattern?** RTK Query auto-subscribes and fetches when `skip` flips `false`. That bypasses the cadence gate — every new leader fires immediately on the tab switch, defeating the whole point of the shared `lastCompletedAt` invariant.
 
 ---
 
@@ -305,9 +381,11 @@ Options for the `broadcast` field on `createRefSignal` / `useRefSignal`.
 | `frame` | `boolean` | — | One send per animation frame. |
 | `rAF` | `boolean` | — | **Deprecated** alias for `frame`. |
 | `onBroadcasterChange` | `(active: boolean) => void` | — | `one-to-many` only: called when this tab gains or loses broadcaster status. |
+| `onStableBroadcasterChange` | `(active: boolean) => void` | — | `one-to-many` only: called when this tab's *stable* broadcaster state changes. Fires `true` once this tab has been broadcaster for `gracePeriod` ms (or synchronously if alone or `gracePeriod` is unset); fires `false` synchronously on losing broadcaster status. |
 | `heartbeatInterval` | `number` | `300` | `one-to-many` only: how often each tab broadcasts a `hello` for peer discovery, in ms. |
 | `heartbeatTimeout` | `number` | `5000` | `one-to-many` only: consider a tab dead after this silence, in ms. |
 | `initialElectionDelay` | `number` | `400` | `one-to-many` only: grace period in ms before the first election after setup or resume. Should be `≥ heartbeatInterval` so the joiner reliably hears the current leader. Set to `0` for synchronous election (accepts the join-flicker). |
+| `gracePeriod` | `number` | — | `one-to-many` only, opt-in. When set, (a) former broadcaster retains emit privileges for this many ms after losing leadership (trailing-emit window), and (b) `useBroadcast`'s `isStableBroadcaster` signal flips `true` only after this many ms have elapsed since gaining leadership — unless alone at election time, in which case the flip is synchronous. See [Smoothing leadership transitions](#smoothing-leadership-transitions--graceperiod). |
 
 ### `BroadcastOptions<TStore>`
 
@@ -340,12 +418,16 @@ import { useBroadcast } from 'react-refsignal/broadcast';
 function useBroadcast<TStore>(
   store: TStore,
   options: BroadcastOptions<TStore>,
-): { isBroadcaster: RefSignal<boolean> }
+): {
+  isBroadcaster: ReadonlyRefSignal<boolean>;
+  isStableBroadcaster: ReadonlyRefSignal<boolean>;
+}
 ```
 
 Hook variant. Sets up broadcast inside a React Provider; tears down on unmount.
 
-- `isBroadcaster` — a `RefSignal<boolean>` that is `true` when this tab is currently sending updates. Always `true` in `many-to-many` mode. In `one-to-many` mode starts `false` and becomes `true` once this tab wins the leader election.
+- `isBroadcaster` — `true` when this tab is currently sending updates. Always `true` in `many-to-many` mode. In `one-to-many` mode starts `false` and becomes `true` once this tab wins the leader election.
+- `isStableBroadcaster` — `true` when this tab is broadcaster *and* has been for at least `gracePeriod` ms — or synchronously, if alone at election time. Identical to `isBroadcaster` when `gracePeriod` is unset. Use to gate work that shouldn't fire during election ambiguity (e.g., `skip: !isStableBroadcaster.current` on an RTK Query hook). See [Smoothing leadership transitions](#smoothing-leadership-transitions--graceperiod).
 
 ---
 

--- a/docs/broadcast.md
+++ b/docs/broadcast.md
@@ -307,6 +307,88 @@ What composes here:
 
 **Why not the non-lazy `useGetMetricQuery` + `skip` pattern?** RTK Query auto-subscribes and fetches when `skip` flips `false`. That bypasses the cadence gate — every new leader fires immediately on the tab switch, defeating the whole point of the shared `lastCompletedAt` invariant.
 
+#### Extracting it as a reusable hook
+
+Once you've seen the pattern, the cadence + broadcast plumbing can fold into a single hook. The caller passes a lazy `trigger` and gets back a broadcast-shared `data` signal:
+
+```tsx
+import { useMemo, useRef } from 'react';
+import {
+  createRefSignal,
+  usePulseRefSignal,
+  useRefSignalEffect,
+  type ReadonlyRefSignal,
+} from 'react-refsignal';
+import { useBroadcast } from 'react-refsignal/broadcast';
+
+interface UseCoordinatedPollOptions<T> {
+  channel: string;
+  interval: number;
+  trigger: () => Promise<T>;
+}
+
+export function useCoordinatedPoll<T>({
+  channel,
+  interval,
+  trigger,
+}: UseCoordinatedPollOptions<T>): {
+  data: ReadonlyRefSignal<T | null>;
+  isStableBroadcaster: ReadonlyRefSignal<boolean>;
+} {
+  const store = useMemo(() => ({
+    data:            createRefSignal<T | null>(null),
+    lastCompletedAt: createRefSignal(0),
+  }), []);
+
+  const triggerRef = useRef(trigger);
+  triggerRef.current = trigger;
+
+  const { isStableBroadcaster } = useBroadcast(store, {
+    channel,
+    mode: 'one-to-many',
+    gracePeriod: interval,
+  });
+
+  const tick = usePulseRefSignal('500ms');
+  useRefSignalEffect(() => {
+    if (!isStableBroadcaster.current) return;
+    if (Date.now() - store.lastCompletedAt.current < interval) return;
+
+    void triggerRef.current().then((payload) => {
+      store.data.update(payload);
+      store.lastCompletedAt.update(Date.now());
+    });
+  }, [tick, isStableBroadcaster, store.lastCompletedAt, interval]);
+
+  return { data: store.data, isStableBroadcaster };
+}
+```
+
+Call site collapses to the essentials — what to fetch, how often, on which channel:
+
+```tsx
+function MetricDashboard() {
+  const [trigger] = useLazyGetMetricQuery();
+
+  const { data } = useCoordinatedPoll({
+    channel: 'metric-poll',
+    interval: 5000,
+    trigger: () => trigger(undefined).unwrap(),
+  });
+
+  return <DataView data={data} />;
+}
+```
+
+Two things to keep in mind when adopting this shape:
+
+- **Broadcast the payload, not just the clock.** `store.data` lives inside the broadcast store, so every tab sees the result — not just the leader that fetched it. A common mistake is to keep `data` as a caller-owned signal updated via an `onData` callback; that saves the network call on follower tabs but leaves them with a stale (or null) view.
+- **`gracePeriod: interval` is a convenient default, not a law.** First-load delay equals `interval` before any poll fires on a contested election. Fine for dashboards on multi-second intervals; if first-paint latency matters, decouple the two (e.g., `gracePeriod: 1000` with `interval: 5000`) — the cadence gate still holds either way.
+
+The `triggerRef` indirection means inline closures (`trigger: () => fetch(...)`) work without `useCallback` — the latest closure is always read at poll time, and the effect's deps stay stable.
+
+Trailing-emit grace covers leadership flips mid-flight: if `trigger()` was in flight when this tab lost leadership, the resolving `store.data.update` and `store.lastCompletedAt.update` calls still propagate (within `gracePeriod` ms), so other tabs see the result without re-fetching.
+
 ---
 
 ## Filtering outgoing updates

--- a/src/broadcast/broadcast.test.ts
+++ b/src/broadcast/broadcast.test.ts
@@ -1657,3 +1657,336 @@ describe('edge cases — persist + broadcast state-handoff race', () => {
     broadcastCleanup();
   });
 });
+
+// ─── gracePeriod — isStableBroadcaster + trailing emit ────────────────────────
+
+describe('gracePeriod — isStableBroadcaster', () => {
+  it('flips true after gracePeriod ms when leader with peers', () => {
+    const store = { score: createRefSignal(0) };
+    const { result } = renderHook(() =>
+      useBroadcast(store, {
+        channel: 'grace-peer',
+        mode: 'one-to-many',
+        initialElectionDelay: 100,
+        gracePeriod: 1000,
+        heartbeatInterval: 2000,
+      }),
+    );
+
+    // Add a higher-ID peer so we're not alone at election time.
+    act(() => {
+      deliverFromOtherTab('grace-peer', {
+        type: 'hello',
+        tabId: 'zzz-peer',
+        ts: Date.now(),
+      });
+    });
+
+    // Election fires.
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(result.current.isBroadcaster.current).toBe(true);
+    expect(result.current.isStableBroadcaster.current).toBe(false);
+
+    // Grace not yet elapsed.
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(result.current.isStableBroadcaster.current).toBe(false);
+
+    // Grace fully elapsed.
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    expect(result.current.isStableBroadcaster.current).toBe(true);
+  });
+
+  it('flips false synchronously on losing leadership', () => {
+    const store = { score: createRefSignal(0) };
+    const { result } = renderHook(() =>
+      useBroadcast(store, {
+        channel: 'grace-lose',
+        mode: 'one-to-many',
+        initialElectionDelay: 100,
+        gracePeriod: 1000,
+        heartbeatInterval: 2000,
+      }),
+    );
+
+    act(() => {
+      deliverFromOtherTab('grace-lose', {
+        type: 'hello',
+        tabId: 'zzz-peer',
+        ts: Date.now(),
+      });
+      jest.advanceTimersByTime(100);
+    });
+
+    // Wait out the grace, become stable.
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current.isStableBroadcaster.current).toBe(true);
+
+    // Lower-ID claim arrives, tab yields.
+    act(() => {
+      deliverFromOtherTab('grace-lose', {
+        type: 'broadcaster-claim',
+        tabId: '0000',
+      });
+    });
+
+    expect(result.current.isBroadcaster.current).toBe(false);
+    expect(result.current.isStableBroadcaster.current).toBe(false);
+  });
+
+  it('flips true synchronously when alone (no peers at election)', () => {
+    const store = { score: createRefSignal(0) };
+    const { result } = renderHook(() =>
+      useBroadcast(store, {
+        channel: 'grace-alone',
+        mode: 'one-to-many',
+        initialElectionDelay: 0,
+        gracePeriod: 5000,
+        heartbeatInterval: 2000,
+      }),
+    );
+
+    // Sole tab — election fires synchronously and grace is skipped.
+    expect(result.current.isBroadcaster.current).toBe(true);
+    expect(result.current.isStableBroadcaster.current).toBe(true);
+
+    // Confirm: no pending timer would fire later.
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    expect(result.current.isStableBroadcaster.current).toBe(true);
+  });
+
+  it('without gracePeriod, behaves identically to isBroadcaster', () => {
+    const store = { score: createRefSignal(0) };
+    const { result } = renderHook(() =>
+      useBroadcast(store, {
+        channel: 'no-grace',
+        mode: 'one-to-many',
+        initialElectionDelay: 100,
+        heartbeatInterval: 2000,
+      }),
+    );
+
+    act(() => {
+      deliverFromOtherTab('no-grace', {
+        type: 'hello',
+        tabId: 'zzz-peer',
+        ts: Date.now(),
+      });
+      jest.advanceTimersByTime(100);
+    });
+
+    // Both flip true together.
+    expect(result.current.isBroadcaster.current).toBe(true);
+    expect(result.current.isStableBroadcaster.current).toBe(true);
+
+    // Both flip false together on yield.
+    act(() => {
+      deliverFromOtherTab('no-grace', {
+        type: 'broadcaster-claim',
+        tabId: '0000',
+      });
+    });
+    expect(result.current.isBroadcaster.current).toBe(false);
+    expect(result.current.isStableBroadcaster.current).toBe(false);
+  });
+
+  it('always true in many-to-many mode', () => {
+    const store = { score: createRefSignal(0) };
+    const { result } = renderHook(() =>
+      useBroadcast(store, {
+        channel: 'grace-m2m',
+        gracePeriod: 5000, // even with grace set, no effect in many-to-many
+      }),
+    );
+
+    expect(result.current.isBroadcaster.current).toBe(true);
+    expect(result.current.isStableBroadcaster.current).toBe(true);
+  });
+
+  it('cancels pending stable timer on losing leadership', () => {
+    const store = { score: createRefSignal(0) };
+    const onStable = jest.fn();
+    renderHook(() =>
+      useBroadcast(store, {
+        channel: 'grace-cancel',
+        mode: 'one-to-many',
+        initialElectionDelay: 100,
+        gracePeriod: 1000,
+        heartbeatInterval: 2000,
+        onStableBroadcasterChange: onStable,
+      }),
+    );
+
+    act(() => {
+      deliverFromOtherTab('grace-cancel', {
+        type: 'hello',
+        tabId: 'zzz-peer',
+        ts: Date.now(),
+      });
+      jest.advanceTimersByTime(100);
+    });
+
+    // Stable timer is pending (scheduled for T=1100); advance partway then yield.
+    act(() => {
+      jest.advanceTimersByTime(500);
+      deliverFromOtherTab('grace-cancel', {
+        type: 'broadcaster-claim',
+        tabId: '0000',
+      });
+    });
+
+    // Advance past the original gracePeriod expiry (T=1100) but stay below the
+    // first heartbeat tick (T=2100) so the heartbeat doesn't re-elect us with
+    // a fresh stable timer — that would be a different timer, not the cancel
+    // we're verifying.
+    act(() => {
+      jest.advanceTimersByTime(1000); // T=1600
+    });
+
+    // We should have seen: stable(false) on yield, and never stable(true).
+    expect(onStable).toHaveBeenCalledWith(false);
+    expect(onStable).not.toHaveBeenCalledWith(true);
+  });
+
+  it('cancels pending stable timer on unmount', () => {
+    const store = { score: createRefSignal(0) };
+    const onStable = jest.fn();
+    const { unmount } = renderHook(() =>
+      useBroadcast(store, {
+        channel: 'grace-unmount',
+        mode: 'one-to-many',
+        initialElectionDelay: 100,
+        gracePeriod: 1000,
+        heartbeatInterval: 2000,
+        onStableBroadcasterChange: onStable,
+      }),
+    );
+
+    act(() => {
+      deliverFromOtherTab('grace-unmount', {
+        type: 'hello',
+        tabId: 'zzz-peer',
+        ts: Date.now(),
+      });
+      jest.advanceTimersByTime(100);
+    });
+
+    // Unmount before grace elapses.
+    act(() => {
+      unmount();
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(onStable).not.toHaveBeenCalledWith(true);
+  });
+});
+
+describe('gracePeriod — trailing emit', () => {
+  it('former leader can emit during gracePeriod window', () => {
+    // Sole-tab setup so this tab is broadcaster from the start.
+    const store = mountScoreBroadcaster({
+      channel: 'grace-trail',
+      mode: 'one-to-many',
+      initialElectionDelay: 0,
+      heartbeatInterval: 2000,
+      gracePeriod: 1000,
+    });
+
+    const received: unknown[] = [];
+    const spy = new MockBC('grace-trail');
+    spy.onmessage = (e) => {
+      if ((e.data as any)?.type === 'update') received.push(e.data);
+    };
+
+    // Lower-ID claim arrives — tab yields (sends state-handoff first).
+    act(() => {
+      deliverFromOtherTab('grace-trail', {
+        type: 'broadcaster-claim',
+        tabId: '0000',
+      });
+    });
+
+    // We're now non-broadcaster but still within gracePeriod.
+    // Update should still propagate as an 'update' message.
+    store.score.update(42);
+
+    expect(received).toHaveLength(1);
+    expect((received[0] as any).payload.score).toBe(42);
+
+    spy.close();
+  });
+
+  it('former leader cannot emit after gracePeriod window', () => {
+    const store = mountScoreBroadcaster({
+      channel: 'grace-trail-expired',
+      mode: 'one-to-many',
+      initialElectionDelay: 0,
+      heartbeatInterval: 2000,
+      gracePeriod: 1000,
+    });
+
+    act(() => {
+      deliverFromOtherTab('grace-trail-expired', {
+        type: 'broadcaster-claim',
+        tabId: '0000',
+      });
+    });
+
+    // Advance past grace window.
+    act(() => {
+      jest.advanceTimersByTime(1100);
+    });
+
+    const received: unknown[] = [];
+    const spy = new MockBC('grace-trail-expired');
+    spy.onmessage = (e) => {
+      if ((e.data as any)?.type === 'update') received.push(e.data);
+    };
+
+    store.score.update(99);
+
+    expect(received).toHaveLength(0);
+
+    spy.close();
+  });
+
+  it('no trailing emit when gracePeriod is unset', () => {
+    const store = mountScoreBroadcaster({
+      channel: 'no-grace-trail',
+      mode: 'one-to-many',
+      initialElectionDelay: 0,
+      heartbeatInterval: 2000,
+      // gracePeriod intentionally omitted
+    });
+
+    act(() => {
+      deliverFromOtherTab('no-grace-trail', {
+        type: 'broadcaster-claim',
+        tabId: '0000',
+      });
+    });
+
+    const received: unknown[] = [];
+    const spy = new MockBC('no-grace-trail');
+    spy.onmessage = (e) => {
+      if ((e.data as any)?.type === 'update') received.push(e.data);
+    };
+
+    // Update immediately after yield — no grace window, should be dropped.
+    store.score.update(7);
+
+    expect(received).toHaveLength(0);
+
+    spy.close();
+  });
+});

--- a/src/broadcast/broadcast.ts
+++ b/src/broadcast/broadcast.ts
@@ -38,9 +38,11 @@ export function setupBroadcast<TStore extends object>(
     mode = 'many-to-many',
     filter,
     onBroadcasterChange,
+    onStableBroadcasterChange,
     heartbeatInterval = 300,
     heartbeatTimeout = 5000,
     initialElectionDelay = 400,
+    gracePeriod,
   } = options;
 
   const transport: Transport = resolveTransport(channel);
@@ -48,10 +50,59 @@ export function setupBroadcast<TStore extends object>(
   // In many-to-many every tab is always a broadcaster; in one-to-many election decides.
   let isBroadcaster = mode === 'many-to-many';
 
+  // Grace-period state (one-to-many only).
+  // `lostBroadcasterAt` enables the trailing-emit window: when this tab loses
+  // broadcaster status, in-flight work that fires `sendSnapshot` within
+  // `gracePeriod` ms still propagates instead of being silently dropped.
+  // `stableTimer` is the deferred flip of `onStableBroadcasterChange(true)`
+  // after a new election — gives the system time to settle (former leader
+  // emitting trailing data, peers stabilizing) before consumers act.
+  let lostBroadcasterAt: number | null = null;
+  let stableTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const withinTrailingGrace = () =>
+    gracePeriod !== undefined &&
+    gracePeriod > 0 &&
+    lostBroadcasterAt !== null &&
+    Date.now() - lostBroadcasterAt < gracePeriod;
+
+  // Single helper that owns every isBroadcaster transition: flips the flag,
+  // fires onBroadcasterChange, manages the stable-timer and lostBroadcasterAt
+  // bookkeeping, then fires onStableBroadcasterChange at the right moment.
+  // Skips grace (fires stable synchronously) when this tab is alone at the
+  // transition — `tabsLastSeen.size <= 1` — so single-tab loads don't wait
+  // a useless `gracePeriod` before becoming stable.
+  const setBroadcasterStatus = (active: boolean) => {
+    if (active === isBroadcaster) return;
+    isBroadcaster = active;
+    onBroadcasterChange?.(active);
+
+    if (stableTimer !== null) {
+      clearTimeout(stableTimer);
+      stableTimer = null;
+    }
+
+    if (active) {
+      lostBroadcasterAt = null;
+      const isAlone = tabsLastSeen.size <= 1;
+      if (gracePeriod !== undefined && gracePeriod > 0 && !isAlone) {
+        stableTimer = setTimeout(() => {
+          stableTimer = null;
+          onStableBroadcasterChange?.(true);
+        }, gracePeriod);
+      } else {
+        onStableBroadcasterChange?.(true);
+      }
+    } else {
+      lostBroadcasterAt = Date.now();
+      onStableBroadcasterChange?.(false);
+    }
+  };
+
   // ── Outgoing ────────────────────────────────────────────────────────────────
 
   const sendSnapshot = () => {
-    if (!isBroadcaster) return;
+    if (!isBroadcaster && !withinTrailingGrace()) return;
     const snapshot = takeSnapshot(store);
     if (filter && !filter(snapshot as StoreSnapshot<TStore>)) return;
     const msg: Msg<Record<string, unknown>> = {
@@ -89,8 +140,7 @@ export function setupBroadcast<TStore extends object>(
     const shouldBe = [...tabsLastSeen.keys()].sort()[0] === TAB_ID;
 
     if (shouldBe && !isBroadcaster && allowClaim) {
-      isBroadcaster = true;
-      onBroadcasterChange?.(true);
+      setBroadcasterStatus(true);
       transport.post({
         type: 'broadcaster-claim',
         tabId: TAB_ID,
@@ -104,8 +154,7 @@ export function setupBroadcast<TStore extends object>(
         tabId: TAB_ID,
         payload: takeSnapshot(store),
       } satisfies Msg<never>);
-      isBroadcaster = false;
-      onBroadcasterChange?.(false);
+      setBroadcasterStatus(false);
     }
   }
 
@@ -154,8 +203,7 @@ export function setupBroadcast<TStore extends object>(
             tabId: TAB_ID,
             payload: takeSnapshot(store),
           } satisfies Msg<never>);
-          isBroadcaster = false;
-          onBroadcasterChange?.(false);
+          setBroadcasterStatus(false);
         }
         break;
     }
@@ -220,8 +268,7 @@ export function setupBroadcast<TStore extends object>(
   if (mode === 'one-to-many') {
     const yieldRole = () => {
       if (isBroadcaster) {
-        isBroadcaster = false;
-        onBroadcasterChange?.(false);
+        setBroadcasterStatus(false);
       }
       stopHeartbeat();
       tabsLastSeen.delete(TAB_ID);
@@ -249,6 +296,10 @@ export function setupBroadcast<TStore extends object>(
     signals.forEach((s) => {
       s.unsubscribe(wrapper.call);
     });
+    if (stableTimer !== null) {
+      clearTimeout(stableTimer);
+      stableTimer = null;
+    }
     if (onVisibilityChange) {
       document.removeEventListener('visibilitychange', onVisibilityChange);
     }

--- a/src/broadcast/types.ts
+++ b/src/broadcast/types.ts
@@ -11,6 +11,13 @@ type BroadcastCommonOptions = {
   /** Called when this tab gains or loses broadcaster status (`mode: 'one-to-many'` only). */
   onBroadcasterChange?: (active: boolean) => void;
   /**
+   * Called when this tab's *stable* broadcaster state changes (`mode: 'one-to-many'` only).
+   * Fires with `true` once this tab has been broadcaster for `gracePeriod` ms — or
+   * synchronously if `gracePeriod` is unset or this tab is alone at election time.
+   * Fires with `false` synchronously when this tab loses broadcaster status.
+   */
+  onStableBroadcasterChange?: (active: boolean) => void;
+  /**
    * How often each tab announces presence with a `hello` heartbeat, in ms.
    * `mode: 'one-to-many'` only. Default: 300.
    *
@@ -23,6 +30,26 @@ type BroadcastCommonOptions = {
   heartbeatInterval?: number;
   /** Consider a tab dead after this many ms of silence. `mode: 'one-to-many'` only. Default: 5000. */
   heartbeatTimeout?: number;
+  /**
+   * Opt-in grace period in ms for leadership transitions. `mode: 'one-to-many'` only.
+   *
+   * When set, two behaviors activate:
+   *
+   * - **Trailing-emit window.** A former broadcaster retains emit privileges for
+   *   `gracePeriod` ms after losing leadership. In-flight work from when this tab
+   *   was leader can still propagate to other tabs instead of being silently dropped.
+   *
+   * - **Delayed `isStableBroadcaster`.** A new broadcaster's `isStableBroadcaster`
+   *   signal flips `true` only after `gracePeriod` ms have elapsed since gaining
+   *   leadership — *unless* this tab is alone (no observed peers at election time),
+   *   in which case the flip is synchronous (no useless wait on single-tab loads).
+   *
+   * Use to gate work that shouldn't fire during election ambiguity — e.g., RTK
+   * Query's `skip: !isStableBroadcaster.current` prevents the new leader from
+   * firing a fresh request the instant after election when the former leader's
+   * trailing data might still be in flight.
+   */
+  gracePeriod?: number;
   /**
    * Delay in ms before running the first election after setup or visibility-resume.
    * `mode: 'one-to-many'` only. Default: 400.

--- a/src/broadcast/useBroadcast.ts
+++ b/src/broadcast/useBroadcast.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { type RefSignal } from '../refsignal';
+import { type ReadonlyRefSignal } from '../refsignal';
 import { useRefSignal } from '../hooks/useRefSignal';
 import { BroadcastOptions } from './types';
 import { setupBroadcast } from './broadcast';
@@ -10,10 +10,14 @@ import { setupBroadcast } from './broadcast';
  *
  * @see [Decision Tree §10 — Cross-tab Broadcast](https://github.com/jav974/react-refsignal/blob/main/docs/decision-tree.md#10-cross-tab-broadcast)
  *
- * Returns `{ isBroadcaster }`:
- * - `isBroadcaster` — a `RefSignal<boolean>` that is `true` when this tab is currently
- *   sending updates. Always `true` in `many-to-many` mode. In `one-to-many` mode starts
- *   `false` and becomes `true` once this tab wins the leader election.
+ * Returns `{ isBroadcaster, isStableBroadcaster }`:
+ * - `isBroadcaster` — `true` when this tab is currently sending updates. Always `true`
+ *   in `many-to-many` mode. In `one-to-many` mode starts `false` and becomes `true`
+ *   once this tab wins the leader election.
+ * - `isStableBroadcaster` — `true` when this tab is broadcaster *and* has been
+ *   for at least `gracePeriod` ms (or alone at election time). Same as `isBroadcaster`
+ *   when `gracePeriod` is unset. Use this to gate work that shouldn't fire during
+ *   election ambiguity — e.g., `skip: !isStableBroadcaster.current` on RTK Query.
  *
  * @example
  * function GameProvider({ children }: { children: ReactNode }) {
@@ -25,27 +29,44 @@ import { setupBroadcast } from './broadcast';
  * @example — restrict localStorage writes to the leader tab only
  * const { isBroadcaster } = useBroadcast(store, { channel: 'game', mode: 'one-to-many' });
  * usePersist(store, { key: 'game', filter: () => isBroadcaster.current });
+ *
+ * @example — gate a periodic poll on stable leadership (5s grace)
+ * const { isStableBroadcaster } = useBroadcast(store, {
+ *   channel: 'metric-poll',
+ *   mode: 'one-to-many',
+ *   gracePeriod: 5000,
+ * });
+ * // Use the LAZY variant — the non-lazy useQuery auto-fires on skip-flip
+ * // and bypasses the cadence gate. Trigger explicitly from a cadence effect.
+ * const [trigger, { data }] = useLazyGetMetricQuery();
  */
 export function useBroadcast<TStore extends object>(
   store: TStore,
   options: BroadcastOptions<TStore>,
-): { isBroadcaster: RefSignal<boolean> } {
+): {
+  isBroadcaster: ReadonlyRefSignal<boolean>;
+  isStableBroadcaster: ReadonlyRefSignal<boolean>;
+} {
   // Keep latest options in a ref so timing/filter/callbacks update without resubscription
   const optionsRef = useRef(options);
   optionsRef.current = options;
 
-  // Stable signal returned to the caller — persists across channel/mode changes.
-  // Initial value mirrors the internal default: many-to-many = always broadcasting.
+  // Stable signals returned to the caller — persist across channel/mode changes.
+  // Initial value mirrors the internal default: many-to-many = always broadcasting,
+  // so isStableBroadcaster matches isBroadcaster from the start in that mode.
   const isBroadcaster = useRefSignal(options.mode !== 'one-to-many');
+  const isStableBroadcaster = useRefSignal(options.mode !== 'one-to-many');
 
   // Resubscribe only when the fundamental identity changes (channel, mode, store)
   const { channel, mode } = options;
 
   useEffect(() => {
     // Reset to the correct initial value for the new channel/mode
-    isBroadcaster.update(optionsRef.current.mode !== 'one-to-many');
+    const initial = optionsRef.current.mode !== 'one-to-many';
+    isBroadcaster.update(initial);
+    isStableBroadcaster.update(initial);
 
-    // Merge caller's onBroadcasterChange with our signal update.
+    // Merge caller's callbacks with our signal updates.
     // Cast required: overriding a non-TStore field (onBroadcasterChange) gives TypeScript
     // no anchor to resolve the spread back to BroadcastOptions<TStore>, so it
     // re-quantifies `filter` as universally generic. The result is correct — tsc agrees.
@@ -55,8 +76,12 @@ export function useBroadcast<TStore extends object>(
         isBroadcaster.update(active);
         optionsRef.current.onBroadcasterChange?.(active);
       },
+      onStableBroadcasterChange: (active: boolean) => {
+        isStableBroadcaster.update(active);
+        optionsRef.current.onStableBroadcasterChange?.(active);
+      },
     } as BroadcastOptions<TStore>);
   }, [store, channel, mode]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  return { isBroadcaster };
+  return { isBroadcaster, isStableBroadcaster };
 }


### PR DESCRIPTION
## Summary

- Adds opt-in `gracePeriod` option to `BroadcastCommonOptions` for `one-to-many` mode.
- Adds `isStableBroadcaster: ReadonlyRefSignal<boolean>` to `useBroadcast`'s return, alongside `isBroadcaster`.
- Tightens existing `isBroadcaster` return type to `ReadonlyRefSignal<boolean>` (broadcast owns this state; external `.update()` was always a bug).
- Documents the **Polling under broadcast** recipe (`LeaderPoller` with shared `lastCompletedAt`, `useLazyGetMetricQuery`, gated cadence effect).

## What this addresses

`one-to-many` broadcast leadership flips with tab visibility. Without coordination, polling fires fresh requests on every leader transition — API flicker. The headline fix is the recipe (broadcast-shared `lastCompletedAt` + cadence effect + lazy-query trigger). `gracePeriod` is an opt-in robustness layer covering two narrower scenarios:

1. **Trailing-emit grace** — a former broadcaster retains emit privileges for `gracePeriod` ms after losing leadership. In-flight work that fires `update()` within this window propagates rather than being silently dropped. Earns its keep with imperative `fetch`.
2. **Delayed `isStableBroadcaster`** — flips `true` only after `gracePeriod` ms have elapsed since gaining leadership. Useful in contested-election scenarios (multi-visible-tab, split-screen, brief visibility overlap).

The delayed flip is **skipped when this tab is alone** at election time, so single-tab loads activate instantly.

## API additions (opt-in, default behavior unchanged)

| Surface | Addition |
|---|---|
| `BroadcastCommonOptions` | `gracePeriod?: number`, `onStableBroadcasterChange?: (active: boolean) => void` |
| `useBroadcast` return | `{ isBroadcaster, isStableBroadcaster }` — both `ReadonlyRefSignal<boolean>` |

## Test plan

- [x] 10 new tests in `broadcast.test.ts`: stable-signal flip semantics, alone-conditional, no-grace default, many-to-many always-stable, timer cancellation on yield + unmount, trailing-emit inside / outside / unset grace window.
- [x] 538 total tests passing.
- [x] TypeScript clean.
- [x] Lint clean.
- [ ] Manual: validate with a real multi-tab polling app (rapid tab switching → no API flicker, 5 s cadence preserved).