### PR TITLE
feat(pulse): pause/resume/stop master controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ The [Decision Tree](docs/decision-tree.md) is intentionally written as a generat
 | `EffectOptions` | Gate and rate-limit re-renders and effects via `filter`, `throttle`, `debounce`, `maxWait`, or `frame` |
 | `createPulseRefSignal` / `usePulseRefSignal` | A signal that ticks on a schedule — `'1000ms'`, `'60fps'`, `'frame'`. Lazy: the timer runs only while subscribed. Carries `dt`, `tick`, `elapsed` metadata |
 | `updatePulse(rate)` | Change a pulse signal's cadence reactively — drive it from another signal for adaptive heartbeats, backoff, perf-budgeted frames |
+| `pause()` / `resume()` / `stop()` | Master control for a running pulse without touching its subscribers — `pause` freezes (resume continues the metrics), `stop` ends the cycle (resets `dt`/`tick`/`elapsed`); both latch so a new subscriber won't restart it |
 | `createRefSignalStore` / `useRefSignalStore` | Provider-free global store — create at module scope, use in any component with `renderOn` opt-in |
 | `createRefSignalContext` | Per-subtree store with auto-generated Provider and hook — for isolated state per route or section |
 | Signal lifetime | Listeners are in a `WeakMap` — GC'd when the signal has no references |

--- a/docs/pulse.md
+++ b/docs/pulse.md
@@ -15,6 +15,7 @@ It replaces three patterns in one primitive:
 - [Quick start](#quick-start)
 - [The shape of a pulse signal](#the-shape-of-a-pulse-signal)
 - [Lifecycle](#lifecycle)
+  - [Master control — `pause` / `resume` / `stop`](#master-control--pause--resume--stop)
 - [Drivers — `setInterval` vs `requestAnimationFrame`](#drivers--setinterval-vs-requestanimationframe)
 - [Reactive cadences with `updatePulse`](#reactive-cadences-with-updatepulse)
 - [Recipes](#recipes)
@@ -100,6 +101,30 @@ Pulse signals are **lazy**. The timer only runs while the signal has at least on
 **Session reset**, not accumulating state. If subscribers go to zero and back — e.g., a component using the signal unmounts and a sibling remounts — the next session starts fresh: `tick = 0`, `elapsed = 0`. The first new tick's `dt` is measured from the new session start, not from whenever the previous session stopped. Otherwise an idle gap would manifest as a single huge `dt` spike — the wrong thing for game/sim code, and meaningless for clocks.
 
 A pulse signal that is never subscribed to never installs a timer. It costs nothing.
+
+### Master control — `pause` / `resume` / `stop`
+
+The lazy lifecycle is subscriber-driven, which is enough when "end the cycle" means "the last consumer goes away." But when a pulse feeds *many* consumers — a game loop driving 50 systems, an animation, a poll — and you want to halt the clock without tearing down and rewiring every listener, reach for the manual controls. They gate the timer independently of the subscriber count: it runs only while there are subscribers **and** the pulse hasn't been paused or stopped.
+
+```ts
+const loop = createPulseRefSignal('frame');
+loop.subscribe(stepPhysics);
+loop.subscribe(stepAnimation); // …and dozens more
+
+loop.pause();   // freeze: timer stops, dt/tick/elapsed hold their values
+loop.resume();  // continue: tick/elapsed pick up where they left off; the
+                // paused gap is excluded from elapsed, and the next dt is
+                // measured from the resume moment
+loop.stop();    // end the cycle: timer stops AND dt/tick/elapsed reset to 0
+loop.resume();  // after stop, resuming begins a fresh epoch (tick from 0)
+```
+
+- **Both `pause` and `stop` latch.** While paused or stopped, even a fresh `0 → 1` subscriber transition will *not* restart the timer — only `resume()` does. This is what makes it a *master* pause: subscriber churn can't silently un-pause your loop.
+- **`pause` preserves, `stop` clears.** `pause` is a suspend/continue (the metrics survive); `stop` ends the current repetition cycle (the metrics reset, so the next start is a clean epoch).
+- **Distinct from `dispose`.** `dispose` is terminal — it tears down the signal. `stop` leaves the signal fully usable; you can `resume()` (or `updatePulse(...)` then `resume()`) for a brand-new cycle later.
+- Each is a no-op in its own state — `pause()` while paused, `resume()` while active, `stop()` while stopped.
+
+The overlay devtools surface these too: the Pulse panel shows each pulse's state and a button to pause/resume/stop it live.
 
 ---
 

--- a/src/devtools/adapter.branches.test.ts
+++ b/src/devtools/adapter.branches.test.ts
@@ -88,6 +88,61 @@ describe('RefSignalDevTools — fallback / edge branches', () => {
     p.dispose();
   });
 
+  it('uses the "pulse?" placeholder for a pulse:state with no signal', () => {
+    devtools.emit({ kind: 'pulse:state', state: 'paused', t: 1 });
+    expect(devtools.getPulseStates()[0]?.pulseId).toBe('pulse?');
+  });
+
+  it('uses the "pulse?" placeholder for a pulse:state from an unregistered signal', () => {
+    const p = createRefSignal(0, 'pStateGone');
+    p.dispose();
+    devtools.emit({ kind: 'pulse:state', signal: p, state: 'stopped', t: 1 });
+    expect(devtools.getPulseStates()[0]?.pulseId).toBe('pulse?');
+  });
+
+  it('keeps the prior state/tickCount/elapsed when a pulse:state omits them', () => {
+    const p = createRefSignal(0, 'pState');
+    devtools.emit({
+      kind: 'pulse:state',
+      signal: p,
+      state: 'paused',
+      tickCount: 7,
+      elapsed: 120,
+      t: 1,
+    });
+    // A later event omits state + tickCount + elapsed → existing values stick.
+    devtools.emit({ kind: 'pulse:state', signal: p, t: 2 });
+    const state = devtools.getPulseStates().find((s) => s.pulseId === 'pState');
+    expect(state?.state).toBe('paused');
+    expect(state?.tickCount).toBe(7);
+    expect(state?.elapsedMs).toBe(120);
+    p.dispose();
+  });
+
+  it('drops the sparkline samples when a pulse:state reports stopped', () => {
+    const p = createRefSignal(0, 'pStopClear');
+    // Seed a sample via a tick, then stop — recent must be cleared.
+    devtools.emit({
+      kind: 'pulse:tick',
+      signal: p,
+      dt: 16,
+      fps: 60,
+      tickCount: 1,
+      elapsed: 16,
+      t: 1,
+    });
+    expect(
+      devtools.getPulseStates().find((s) => s.pulseId === 'pStopClear')?.recent
+        .length,
+    ).toBe(1);
+    devtools.emit({ kind: 'pulse:state', signal: p, state: 'stopped', t: 2 });
+    expect(
+      devtools.getPulseStates().find((s) => s.pulseId === 'pStopClear')?.recent
+        .length,
+    ).toBe(0);
+    p.dispose();
+  });
+
   it('applies defaults for omitted broadcast channel fields', () => {
     devtools.emit({ kind: 'broadcast:peers', channel: 'bare', t: 1 });
     const ch = devtools

--- a/src/devtools/adapter.ts
+++ b/src/devtools/adapter.ts
@@ -5,6 +5,7 @@ import {
   type DevToolsEvent,
   type RefSignal,
 } from '../refsignal';
+import type { PulseRefSignal } from '../pulse';
 import { currentEffect, popEffect, pushEffect } from './effect-stack';
 
 export interface DevToolsConfig {
@@ -51,6 +52,7 @@ export interface PulseState {
   tickCount: number;
   elapsedMs: number;
   recent: PulseSample[];
+  state: 'active' | 'paused' | 'stopped';
 }
 
 export interface BroadcastPeer {
@@ -302,6 +304,8 @@ class RefSignalDevTools implements DevToolsAdapter {
     //   ever) so it can't ride the ring's eviction policy.
     if (event.kind === 'pulse:tick') {
       this.recordPulseTick(event);
+    } else if (event.kind === 'pulse:state') {
+      this.recordPulseState(event);
     } else if (event.kind === 'broadcast:peers') {
       this.recordBroadcastChannel(event);
     } else {
@@ -321,9 +325,17 @@ class RefSignalDevTools implements DevToolsAdapter {
     const id = sig ? (this.signals.get(sig as object) ?? 'pulse?') : 'pulse?';
     let state = this.pulses.get(id);
     if (!state) {
-      state = { pulseId: id, tickCount: 0, elapsedMs: 0, recent: [] };
+      state = {
+        pulseId: id,
+        tickCount: 0,
+        elapsedMs: 0,
+        recent: [],
+        state: 'active',
+      };
       this.pulses.set(id, state);
     }
+    // A tick means the pulse is live again — clears a prior paused/stopped flag.
+    state.state = 'active';
     state.tickCount =
       (event.tickCount as number | undefined) ?? state.tickCount;
     state.elapsedMs = (event.elapsed as number | undefined) ?? state.elapsedMs;
@@ -337,11 +349,55 @@ class RefSignalDevTools implements DevToolsAdapter {
     }
   }
 
+  private recordPulseState(event: DevToolsEvent): void {
+    const sig = event.signal as RefSignal | undefined;
+    const id = sig ? (this.signals.get(sig as object) ?? 'pulse?') : 'pulse?';
+    let state = this.pulses.get(id);
+    if (!state) {
+      state = {
+        pulseId: id,
+        tickCount: 0,
+        elapsedMs: 0,
+        recent: [],
+        state: 'active',
+      };
+      this.pulses.set(id, state);
+    }
+    state.state =
+      (event.state as PulseState['state'] | undefined) ?? state.state;
+    state.tickCount =
+      (event.tickCount as number | undefined) ?? state.tickCount;
+    state.elapsedMs = (event.elapsed as number | undefined) ?? state.elapsedMs;
+    // A stopped pulse cleared its session — drop the frozen sparkline so the
+    // panel doesn't pair a stale trace with a 0/0 readout.
+    if (state.state === 'stopped') {
+      state.recent = [];
+    }
+  }
+
   getPulseStates(): PulseState[] {
     return Array.from(this.pulses.values()).map((p) => ({
       ...p,
       recent: p.recent.slice(),
     }));
+  }
+
+  /**
+   * Resolve a pulse's imperative controls by id, for the overlay's
+   * pause/resume/stop button. Reads the live signal from the dispose-cleaned
+   * registry, so it returns undefined once the pulse is disposed and the
+   * control hides itself — no strong ref is retained here.
+   */
+  getPulseControl(
+    pulseId: string,
+  ): Pick<PulseRefSignal, 'pause' | 'resume' | 'stop'> | undefined {
+    const sig = this.signalEntries.get(pulseId)?.signal as
+      | Partial<PulseRefSignal>
+      | undefined;
+    if (sig && typeof sig.pause === 'function') {
+      return sig as Pick<PulseRefSignal, 'pause' | 'resume' | 'stop'>;
+    }
+    return undefined;
   }
 
   private recordBroadcastChannel(event: DevToolsEvent): void {

--- a/src/devtools/overlay/panels/PulsePanel.tsx
+++ b/src/devtools/overlay/panels/PulsePanel.tsx
@@ -65,6 +65,13 @@ export function PulsePanel() {
     <div>
       {pulses.map((p) => {
         const lastFps = p.recent[p.recent.length - 1]?.fps;
+        const control = devtools.getPulseControl(p.pulseId);
+        const stateColor =
+          p.state === 'active'
+            ? s.colors.success
+            : p.state === 'paused'
+              ? s.colors.warn
+              : s.colors.error;
         return (
           <div key={p.pulseId} style={s.card}>
             <div
@@ -72,13 +79,50 @@ export function PulsePanel() {
                 ...s.cardTitle,
                 display: 'flex',
                 justifyContent: 'space-between',
+                alignItems: 'center',
               }}
             >
               <span>{p.pulseId}</span>
-              <span style={s.chip(s.colors.accentDim)}>
-                {lastFps !== undefined ? `${lastFps.toFixed(1)} fps` : '—'}
+              <span style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <span style={s.chip(stateColor)}>{p.state}</span>
+                <span style={s.chip(s.colors.accentDim)}>
+                  {lastFps !== undefined ? `${lastFps.toFixed(1)} fps` : '—'}
+                </span>
               </span>
             </div>
+            {control && (
+              <div style={{ display: 'flex', gap: 6, marginBottom: 8 }}>
+                {p.state === 'active' ? (
+                  <button
+                    style={s.controlBtn}
+                    onClick={() => {
+                      control.pause();
+                    }}
+                  >
+                    Pause
+                  </button>
+                ) : (
+                  <button
+                    style={s.controlBtn}
+                    onClick={() => {
+                      control.resume();
+                    }}
+                  >
+                    Resume
+                  </button>
+                )}
+                {p.state !== 'stopped' && (
+                  <button
+                    style={s.controlBtn}
+                    onClick={() => {
+                      control.stop();
+                    }}
+                  >
+                    Stop
+                  </button>
+                )}
+              </div>
+            )}
             <div style={{ display: 'flex', gap: 12, alignItems: 'flex-end' }}>
               <Sparkline samples={p.recent} />
               <div style={{ flex: 1 }}>

--- a/src/devtools/overlay/panels/panels.test.tsx
+++ b/src/devtools/overlay/panels/panels.test.tsx
@@ -4,6 +4,7 @@
 import { act } from 'react';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { createRefSignal } from '../../../refsignal';
+import { createPulseRefSignal } from '../../../pulse';
 import { devtools } from '../../adapter';
 import { BroadcastPanel } from './BroadcastPanel';
 import { CascadePanel } from './CascadePanel';
@@ -274,6 +275,104 @@ describe('PulsePanel', () => {
     render(<PulsePanel />);
     expect(screen.getByText('noFps')).toBeTruthy();
     expect(screen.getByText('—')).toBeTruthy();
+  });
+
+  const seedPulse = (state: 'active' | 'paused' | 'stopped', name: string) => {
+    const p = createPulseRefSignal(100, name);
+    emit({
+      kind: 'pulse:state',
+      signal: p,
+      state,
+      tickCount: 0,
+      elapsed: 0,
+      dt: 0,
+      t: Date.now(),
+    });
+    return p;
+  };
+
+  it('offers Pause + Stop for an active pulse', () => {
+    const p = seedPulse('active', 'pActive');
+    render(<PulsePanel />);
+    expect(screen.getByText('active')).toBeTruthy();
+    expect(screen.getByText('Pause')).toBeTruthy();
+    expect(screen.getByText('Stop')).toBeTruthy();
+    expect(screen.queryByText('Resume')).toBeNull();
+    p.dispose();
+  });
+
+  it('offers Resume + Stop for a paused pulse', () => {
+    const p = seedPulse('paused', 'pPaused');
+    render(<PulsePanel />);
+    expect(screen.getByText('paused')).toBeTruthy();
+    expect(screen.getByText('Resume')).toBeTruthy();
+    expect(screen.getByText('Stop')).toBeTruthy();
+    expect(screen.queryByText('Pause')).toBeNull();
+    p.dispose();
+  });
+
+  it('offers only Resume for a stopped pulse', () => {
+    const p = seedPulse('stopped', 'pStopped');
+    render(<PulsePanel />);
+    expect(screen.getByText('stopped')).toBeTruthy();
+    expect(screen.getByText('Resume')).toBeTruthy();
+    expect(screen.queryByText('Stop')).toBeNull();
+    expect(screen.queryByText('Pause')).toBeNull();
+    p.dispose();
+  });
+
+  it('wires a control button to the live pulse signal', () => {
+    const p = seedPulse('active', 'pWired');
+    render(<PulsePanel />);
+    act(() => {
+      fireEvent.click(screen.getByText('Pause'));
+    });
+    // The click reached the live signal: its emitted state landed in the adapter
+    // and the chip reflects the single transition.
+    expect(devtools.getPulseStates()[0]?.state).toBe('paused');
+    expect(screen.getByText('paused')).toBeTruthy();
+    p.dispose();
+  });
+
+  it('Stop button ends the cycle on the live pulse', () => {
+    const p = seedPulse('active', 'pStopBtn');
+    render(<PulsePanel />);
+    act(() => {
+      fireEvent.click(screen.getByText('Stop'));
+    });
+    expect(devtools.getPulseStates()[0]?.state).toBe('stopped');
+    p.dispose();
+  });
+
+  it('Resume button reactivates a paused live pulse', () => {
+    const p = createPulseRefSignal(100, 'pResumeBtn');
+    p.pause(); // really pause the signal so the panel shows Resume
+    render(<PulsePanel />);
+    act(() => {
+      fireEvent.click(screen.getByText('Resume'));
+    });
+    expect(devtools.getPulseStates()[0]?.state).toBe('active');
+    p.dispose();
+  });
+
+  it('hides the controls once the pulse is disposed', () => {
+    const p = createPulseRefSignal(100, 'disposed');
+    emit({
+      kind: 'pulse:state',
+      signal: p,
+      state: 'paused',
+      tickCount: 3,
+      elapsed: 300,
+      dt: 0,
+      t: Date.now(),
+    });
+    p.dispose(); // registry entry removed → getPulseControl returns undefined
+
+    render(<PulsePanel />);
+    // The pulse's last state still shows, but the control buttons are gone.
+    expect(screen.getByText('disposed')).toBeTruthy();
+    expect(screen.queryByText('Resume')).toBeNull();
+    expect(screen.queryByText('Pause')).toBeNull();
   });
 });
 

--- a/src/devtools/overlay/styles.ts
+++ b/src/devtools/overlay/styles.ts
@@ -92,6 +92,17 @@ export const iconBtn: CSSProperties = {
   fontFamily: 'inherit',
 };
 
+export const controlBtn: CSSProperties = {
+  background: colors.bg,
+  color: colors.text,
+  border: `1px solid ${colors.border}`,
+  borderRadius: 3,
+  cursor: 'pointer',
+  padding: '2px 8px',
+  fontSize: 10,
+  fontFamily: 'inherit',
+};
+
 export const rateSelect: CSSProperties = {
   background: colors.bg,
   color: colors.textMuted,

--- a/src/pulse.test.ts
+++ b/src/pulse.test.ts
@@ -491,6 +491,192 @@ describe('createPulseRefSignal', () => {
     });
   });
 
+  describe('pause / resume / stop', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('pause halts firing while keeping the subscriber attached', () => {
+      const s = createPulseRefSignal(100);
+      const a = jest.fn();
+      s.subscribe(a);
+      jest.advanceTimersByTime(100);
+      expect(a).toHaveBeenCalledTimes(1);
+
+      s.pause();
+      jest.advanceTimersByTime(1000);
+      expect(a).toHaveBeenCalledTimes(1); // no further ticks while paused
+      s.dispose();
+    });
+
+    it('pause clears the underlying interval', () => {
+      const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+      const s = createPulseRefSignal(100);
+      s.subscribe(jest.fn());
+      s.pause();
+      expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+      s.dispose();
+      clearIntervalSpy.mockRestore();
+    });
+
+    it('resume after pause continues tick/elapsed, excluding the paused gap', () => {
+      let nowVal = 1000;
+      const perfSpy = jest
+        .spyOn(performance, 'now')
+        .mockImplementation(() => nowVal);
+      const s = createPulseRefSignal(100);
+      s.subscribe(jest.fn());
+
+      nowVal = 1100;
+      jest.advanceTimersByTime(100);
+      nowVal = 1200;
+      jest.advanceTimersByTime(100);
+      expect(s.tick).toBe(2);
+      expect(s.elapsed).toBe(100);
+
+      // Pause right on the last tick boundary; counters freeze.
+      s.pause();
+      expect(s.tick).toBe(2);
+      expect(s.elapsed).toBe(100);
+
+      // 300ms paused gap — no ticks.
+      nowVal = 1500;
+      jest.advanceTimersByTime(1000);
+      expect(s.tick).toBe(2);
+
+      s.resume();
+      // Next tick: tick continues (3), dt measured from resume, elapsed excludes
+      // the 300ms gap (200 = 100 before + 100 active after).
+      nowVal = 1600;
+      jest.advanceTimersByTime(100);
+      expect(s.tick).toBe(3);
+      expect(s.dt).toBe(100);
+      expect(s.elapsed).toBe(200);
+
+      s.dispose();
+      perfSpy.mockRestore();
+    });
+
+    it('pause is latching — a fresh subscriber does NOT restart it', () => {
+      const s = createPulseRefSignal(100);
+      const a = jest.fn();
+      s.subscribe(a);
+      jest.advanceTimersByTime(100);
+      expect(a).toHaveBeenCalledTimes(1);
+
+      s.pause();
+      s.unsubscribe(a);
+      s.subscribe(a); // 0 → 1 transition, but paused — must not start
+      jest.advanceTimersByTime(1000);
+      expect(a).toHaveBeenCalledTimes(1);
+
+      // Only an explicit resume re-arms.
+      s.resume();
+      jest.advanceTimersByTime(100);
+      expect(a).toHaveBeenCalledTimes(2);
+      s.dispose();
+    });
+
+    it('stop halts and resets dt/tick/elapsed to zero', () => {
+      let nowVal = 1000;
+      const perfSpy = jest
+        .spyOn(performance, 'now')
+        .mockImplementation(() => nowVal);
+      const s = createPulseRefSignal(100);
+      const a = jest.fn();
+      s.subscribe(a);
+      nowVal = 1100;
+      jest.advanceTimersByTime(100);
+      nowVal = 1200;
+      jest.advanceTimersByTime(100);
+      expect(s.tick).toBe(2);
+      expect(s.elapsed).toBe(100);
+
+      s.stop();
+      expect(s.tick).toBe(0);
+      expect(s.elapsed).toBe(0);
+      expect(s.dt).toBe(0);
+
+      // Latching: no further ticks even though the subscriber is still attached.
+      jest.advanceTimersByTime(1000);
+      expect(s.tick).toBe(0);
+      expect(a).toHaveBeenCalledTimes(2);
+
+      s.dispose();
+      perfSpy.mockRestore();
+    });
+
+    it('resume after stop begins a fresh epoch', () => {
+      let nowVal = 1000;
+      const perfSpy = jest
+        .spyOn(performance, 'now')
+        .mockImplementation(() => nowVal);
+      const s = createPulseRefSignal(100);
+      s.subscribe(jest.fn());
+      nowVal = 1100;
+      jest.advanceTimersByTime(100);
+      expect(s.tick).toBe(1);
+
+      s.stop();
+      nowVal = 9000; // long gap before resume
+      s.resume();
+
+      // First tick of the fresh epoch: tick 1, elapsed 0, dt from resume.
+      nowVal = 9100;
+      jest.advanceTimersByTime(100);
+      expect(s.tick).toBe(1);
+      expect(s.elapsed).toBe(0);
+      expect(s.dt).toBe(100);
+
+      s.dispose();
+      perfSpy.mockRestore();
+    });
+
+    it('stop is latching against subscriber churn', () => {
+      const s = createPulseRefSignal(100);
+      const a = jest.fn();
+      s.subscribe(a);
+      jest.advanceTimersByTime(100);
+      s.stop();
+      s.unsubscribe(a);
+      s.subscribe(a); // 0 → 1, but stopped — must not start
+      jest.advanceTimersByTime(1000);
+      expect(a).toHaveBeenCalledTimes(1);
+      s.dispose();
+    });
+
+    it('resume with no subscribers waits for the next subscriber', () => {
+      const setIntervalSpy = jest.spyOn(global, 'setInterval');
+      const s = createPulseRefSignal(100);
+      s.stop(); // no subscribers
+      s.resume();
+      expect(setIntervalSpy).not.toHaveBeenCalled(); // nothing to arm yet
+
+      const a = jest.fn();
+      s.subscribe(a); // active again — 0 → 1 starts
+      jest.advanceTimersByTime(100);
+      expect(a).toHaveBeenCalledTimes(1);
+      s.dispose();
+      setIntervalSpy.mockRestore();
+    });
+
+    it('pause / resume / stop are idempotent no-ops in their own state', () => {
+      const s = createPulseRefSignal(100);
+      s.subscribe(jest.fn());
+      expect(() => {
+        s.resume(); // already active
+        s.pause();
+        s.pause(); // already paused
+        s.stop();
+        s.stop(); // already stopped
+      }).not.toThrow();
+      s.dispose();
+    });
+  });
+
   describe('RAF driver (fps notation)', () => {
     let raf: ReturnType<typeof setupRafMock>;
     beforeEach(() => {

--- a/src/pulse.ts
+++ b/src/pulse.ts
@@ -75,6 +75,45 @@ export interface PulseRefSignal extends ReadonlyRefSignal<number> {
    * }, [stamina]);
    */
   readonly updatePulse: (rate: PulseRate) => void;
+  /**
+   * Suspend the pulse while keeping every subscriber attached. The timer stops
+   * firing and the session metrics (`dt`, `tick`, `elapsed`) freeze at their
+   * current values.
+   *
+   * Latching: while paused, even a fresh `0 → 1` subscriber transition will
+   * **not** restart the timer — only {@link resume} does. This is the master
+   * pause for a loop feeding many consumers (a game loop, an animation, a
+   * poll): halt the clock without tearing down and rewiring its listeners.
+   *
+   * No-op if not currently active.
+   */
+  readonly pause: () => void;
+  /**
+   * Resume an already-{@link pause}d or {@link stop}ped pulse. Re-arms the
+   * timer immediately if subscribers are attached (otherwise the next
+   * `0 → 1` subscriber transition starts it, as usual).
+   *
+   * - After `pause()`: metrics **continue** — `tick`/`elapsed` keep their
+   *   values and `elapsed` excludes the paused gap; the next `dt` is measured
+   *   from the resume moment.
+   * - After `stop()`: metrics were cleared, so resuming begins a fresh epoch
+   *   (`tick` from `0`).
+   *
+   * No-op if already active.
+   */
+  readonly resume: () => void;
+  /**
+   * End the current repetition cycle. Halts the timer and **resets** the
+   * session metrics (`dt`, `tick`, `elapsed`) to `0`. Like {@link pause} it is
+   * latching — new subscribers will not restart it; a {@link resume} (or a
+   * fresh `updatePulse`-then-resume) starts a brand-new cycle.
+   *
+   * Distinct from `dispose`: the signal stays usable and re-startable; only
+   * this cycle is cleared.
+   *
+   * No-op if already stopped.
+   */
+  readonly stop: () => void;
 }
 
 interface ParsedRate {
@@ -211,6 +250,9 @@ export function createPulseRefSignal(
   let firstTickTime = 0;
   let lastTickTime = 0;
   let stopTimer: (() => void) | null = null;
+  let runState: 'active' | 'paused' | 'stopped' = 'active';
+
+  const subscriberCount = (): number => listenersMap.get(signal)?.size ?? 0;
 
   const onTick = () => {
     const now = performance.now();
@@ -237,8 +279,23 @@ export function createPulseRefSignal(
     });
   };
 
+  const emitState = () => {
+    getDevToolsAdapter()?.emit({
+      kind: 'pulse:state',
+      signal,
+      state: runState,
+      dt,
+      tickCount,
+      elapsed,
+      t: Date.now(),
+    });
+  };
+
   const installTimer = () => {
     if (typeof window === 'undefined') return;
+    // Reached only while active: start() runs only on the active-state 0 → 1
+    // transition, resume() flips to active before calling, and updatePulse bails
+    // unless a timer is already running (which implies active).
     stopTimer =
       parsed.driver === 'raf'
         ? startRAFTimer(parsed.intervalMs, onTick)
@@ -256,7 +313,7 @@ export function createPulseRefSignal(
     installTimer();
   };
 
-  const stop = () => {
+  const haltTimer = () => {
     if (stopTimer) {
       stopTimer();
       stopTimer = null;
@@ -272,12 +329,45 @@ export function createPulseRefSignal(
     // Continuity: keep tick / elapsed accumulating, only baseline lastTickTime
     // so the next dt reflects the rate change rather than spanning the
     // restart.
-    stop();
+    haltTimer();
     lastTickTime = performance.now();
     installTimer();
   };
 
-  const subscriberCount = (): number => listenersMap.get(signal)?.size ?? 0;
+  const pause = () => {
+    if (runState !== 'active') return;
+    runState = 'paused';
+    haltTimer(); // metrics freeze at their current values
+    emitState();
+  };
+
+  const stop = () => {
+    if (runState === 'stopped') return;
+    runState = 'stopped';
+    haltTimer();
+    // End the cycle: clear the session so the next resume starts fresh.
+    dt = 0;
+    tickCount = 0;
+    elapsed = 0;
+    firstTickTime = 0;
+    lastTickTime = 0;
+    emitState();
+  };
+
+  const resume = () => {
+    if (runState === 'active') return;
+    // Resuming from pause: shift the epoch forward by the idle gap so `elapsed`
+    // excludes paused time and the next `dt` measures from resume rather than
+    // spanning the gap. After stop, counters are already 0 (lastTickTime === 0),
+    // so this is skipped and the next tick begins a fresh epoch.
+    if (lastTickTime > 0) {
+      firstTickTime += performance.now() - lastTickTime;
+    }
+    lastTickTime = performance.now();
+    runState = 'active';
+    if (subscriberCount() > 0) installTimer();
+    emitState();
+  };
 
   const baseSubscribe = signal.subscribe;
   const baseUnsubscribe = signal.unsubscribe;
@@ -287,17 +377,22 @@ export function createPulseRefSignal(
     subscribe: (listener: Listener<number>) => {
       const before = subscriberCount();
       baseSubscribe(listener);
-      if (before === 0 && subscriberCount() === 1) start();
+      // Latching pause/stop: only re-arm on the 0 → 1 transition while active.
+      if (before === 0 && subscriberCount() === 1 && runState === 'active')
+        start();
     },
     unsubscribe: (listener: Listener<number>) => {
       baseUnsubscribe(listener);
-      if (subscriberCount() === 0) stop();
+      if (subscriberCount() === 0) haltTimer();
     },
     dispose: () => {
-      stop();
+      haltTimer();
       baseDispose();
     },
     updatePulse,
+    pause,
+    resume,
+    stop,
   });
 
   Object.defineProperties(signal, {


### PR DESCRIPTION
## What

Adds three imperative controls to `PulseRefSignal` so a pulse feeding many consumers can be halted and restarted **without tearing down and rewiring its subscribers**:

- **`pause()`** — freeze the clock; `dt`/`tick`/`elapsed` hold their values. `resume()` continues them (the paused gap is excluded from `elapsed`, and the next `dt` is measured from the resume moment).
- **`stop()`** — end the current repetition cycle: halt **and** reset `dt`/`tick`/`elapsed` to `0`. `resume()` after a stop begins a fresh epoch.
- **`resume()`** — re-arm the timer if subscribers are attached; otherwise the next `0 → 1` subscriber transition starts it.

Both `pause` and `stop` **latch** — while paused or stopped, a fresh subscriber transition will *not* restart the timer; only `resume()` does. This is what makes it a *master* pause: subscriber churn can't silently un-pause your loop. Distinct from `dispose`, which is terminal.

## Why

The lazy lifecycle (timer runs only while subscribed) already covers "end the cycle when the last consumer leaves." The gap was a master pause for a pulse with *many* live consumers — a game loop, an animation, a poll — where unsubscribing/rewiring every listener to halt is awkward and lossy.

## How

- Two orthogonal gates: the timer runs only while `hasSubscribers && runState === 'active'`.
- New `pulse:state` devtools event on every transition; the overlay **Pulse panel** shows each pulse's state and a live pause/resume/stop button.
- `adapter.getPulseControl(id)` resolves the live signal from the dispose-cleaned registry — no strong ref retained, so the control disappears once the pulse is disposed.

## Tests

- 10 core cases in `pulse.test.ts` — latching, pause continuity, fresh-epoch-after-stop, idempotent no-ops.
- 5 panel cases in `panels.test.tsx` — per-state controls, button wiring, hide-after-dispose.
- Full suite: **681/681 src tests pass**, `src/` lints clean, typecheck + build green.

## Docs

- README API table row.
- New "Master control — pause / resume / stop" section in `docs/pulse.md`.
