### PR TITLE
feat: delayed timing option + replay signals

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -21,8 +21,10 @@
 - [`useRefSignalMemo<T>(factory, deps, options?)`](#userefsignalmemot-factory-deps-options)
 - [`useRefSignalFollow<T>(getter, deps, options?)`](#userefsignalfollowt-getter-deps-options)
 - [`usePulseRefSignal(rate)`](#usepulserefsignalrate)
+- [`useReplayRefSignal<T>(source, ms, snapshot?)`](#usereplayrefsignalt-source-ms-snapshot)
 - [`createComputedRefSignal<T>(compute, deps)`](#createcomputedrefsignalt-compute-deps)
 - [`createPulseRefSignal(rate)`](#createpulserefsignalrate)
+- [`createReplayRefSignal<T>(source, ms, snapshot?)`](#createreplayrefsignalt-source-ms-snapshot)
 - [`watch<T>(signal, listener, options?)`](#watcht-signal-listener-options)
 - [`watchSignals(deps, onFire, options?)`](#watchsignalsdeps-onfire-options)
 - [`WatchHandle`](#watchhandle)
@@ -314,7 +316,7 @@ TimingOptions
 |---|---|---|
 | `filter` | `() => boolean` | Skip the callback when this returns `false`. Does not gate the dynamic-tracking reconcile pass — the subscription set stays consistent regardless of filter state. |
 | `trackSignals` | `() => ReadonlyArray<RefSignal<unknown>>` | Resolves additional signals to subscribe to dynamically. Re-evaluated only on fires of static `deps` signals (not on fires of the returned set itself). The diff runs with ref-equal and content-equal shortcuts, so returning a memoized array or the same content each call costs nothing. Use for nested-signal traversal where an inner signal's identity comes from another signal's current value. Prefer [`useRefSignalFollow`](#userefsignalfollowt-getter-deps-options) for the common single-signal case. |
-| `throttle` / `debounce` / `maxWait` / `frame` | — | See [`TimingOptions`](#timingoptions). |
+| `throttle` / `debounce` / `maxWait` / `delayed` / `frame` | — | See [`TimingOptions`](#timingoptions). |
 
 ---
 
@@ -331,6 +333,7 @@ Options accepted by `useRefSignalEffect`. Extends [`WatchOptions`](#watchoptions
 | `throttle` | `number` | At most one trigger per N ms (leading + trailing). |
 | `debounce` | `number` | Trigger after N ms of quiet. |
 | `maxWait` | `number` | With `debounce` only: guaranteed flush every N ms even if the signal keeps firing. |
+| `delayed` | `number` | Trigger exactly N ms after the *first* fire of a burst, reading live state at run time. Sugar for `{ debounce: N, maxWait: N }`. Need the value *as it was* N ms ago instead? See [`useReplayRefSignal`](#usereplayrefsignalt-source-ms-snapshot). |
 | `frame` | `boolean` | Schedule on the next animation frame (`requestAnimationFrame`); multiple fires per frame collapse into one. |
 | `rAF` | `boolean` | **Deprecated** alias for `frame`. Still works; will be removed in a future major version. |
 
@@ -340,7 +343,9 @@ The timing options are mutually exclusive — combining them is a type error:
 { throttle: 100, debounce: 200 } // ✗ type error
 { maxWait: 500 }                 // ✗ type error — maxWait requires debounce
 { frame: true, throttle: 50 }   // ✗ type error
+{ delayed: 100, frame: true }   // ✗ type error
 { debounce: 200, maxWait: 1000 } // ✓
+{ delayed: 100 }                 // ✓
 ```
 
 Context hooks (`createRefSignalContext`, `createRefSignalContextHook`) accept [`SignalStoreOptions`](#signalstoreoptionststore) instead, which extends these same fields but upgrades `filter` to receive the store snapshot directly.
@@ -454,6 +459,33 @@ function GameLoop() {
 
 ---
 
+### `useReplayRefSignal<T>(source, ms, snapshot?)`
+
+Creates a read-only signal that follows `source` exactly `ms` milliseconds behind — every source update is captured and re-emitted once its due time arrives, preserving order and relative spacing. The *time-shifted value* primitive: trails, ghosts, delayed playback. The signal is stable for the component's lifetime and torn down on unmount; React owns the lifecycle, so `.dispose()` is not exposed.
+
+```tsx
+import { useRefSignal, useReplayRefSignal, useRefSignalEffect } from 'react-refsignal';
+
+function NodeWithGhost() {
+  const pos = useRefSignal({ x: 0, y: 0 });
+  const ghost = useReplayRefSignal(pos, 300, (p) => ({ ...p }));
+
+  useRefSignalEffect(() => {
+    drawGhost(ctx, ghost.current.x, ghost.current.y);
+  }, [ghost], { frame: true });
+  // …
+}
+```
+
+- Consumer code is identical to consuming the live source — point it at a different signal, and pick any consumption timing (`frame`, `throttle`, `debounce`, none) downstream. Each due entry is an individual update, so an untimed subscriber observes every replayed value.
+- **`snapshot` is required for object signals mutated in place** (the `.current.x = …; .notify()` hot-path idiom) — without it the internal queue holds references to one live object and every replayed emission shows the present, not the past. Immutably-updated signals and primitives don't need it; the default identity capture is allocation-free.
+- `source`, `ms`, and `snapshot` are captured at mount time, mirroring the mount-time-options convention of [`useRefSignal`](#userefsignalt-initialvalue-options).
+- Want an effect to simply run N ms *after* a change, reading live state? That's not a replay — use the [`{ delayed: N }`](#timingoptions) timing option.
+
+Outside React, use [`createReplayRefSignal`](#createreplayrefsignalt-source-ms-snapshot). See [Patterns — Time-shifted signals](patterns.md#time-shifted-signals--usereplayrefsignal) for the recipe.
+
+---
+
 ### `createComputedRefSignal<T>(compute, deps)`
 
 Creates a derived signal whose value is recomputed whenever any dep signal updates. The returned signal is read-only — `.update()` and `.reset()` are not exposed.
@@ -507,6 +539,29 @@ const everyHalf = createPulseRefSignal(500);      // bare number — same as '50
 - SSR-safe: construction works in non-browser environments (so server output is stable), but no timer is installed when `typeof window === 'undefined'`. The timer starts naturally on the client after hydration.
 
 For full narrative, recipes, and the store-level composition trap, see [Pulse](pulse.md).
+
+---
+
+### `createReplayRefSignal<T>(source, ms, snapshot?)`
+
+Creates a replayed signal outside React — at module scope, in context factories, or anywhere else. Same semantics as [`useReplayRefSignal`](#usereplayrefsignalt-source-ms-snapshot); returns the signal augmented with `.dispose()`.
+
+```ts
+import { createRefSignal, createReplayRefSignal, watch } from 'react-refsignal';
+
+const price = createRefSignal(0, 'price');
+const delayedPrice = createReplayRefSignal(price, 5000); // price, 5 s ago
+
+watch(delayedPrice, (v) => updateComparisonChart(v));
+
+// Later — stop following the source, cancel pending emissions, release subscribers
+delayedPrice.dispose();
+```
+
+- Emissions fire at their due moment via a single armed `setTimeout` — at most one timer exists at a time, and none while the source is quiet. A quiet replay signal costs one listener entry on the source.
+- The drain is intentionally not configurable — any timing policy on the emission side would corrupt the "value as it was `ms` ago" contract. Consumption timing belongs downstream, per consumer.
+- Works in non-browser environments (no `requestAnimationFrame` dependency) and keeps progressing in background tabs, subject to browser timer throttling.
+- Throws on a negative or non-finite `ms`.
 
 ---
 

--- a/docs/decision-tree.md
+++ b/docs/decision-tree.md
@@ -109,8 +109,11 @@ flowchart TD
     C --> Q2{"Guarantee a flush even if signal keeps firing?"}
     Q2 -->|Yes| D["Add maxWait: N"]
     Q2 -->|No| E[Done]
+    Q1 -->|"Exactly N ms after the first fire of a burst"| G["delayed: N"]
     Q1 -->|"Sync to animation frame — collapse multiple fires per frame"| F["frame: true"]
 ```
+
+> `delayed: N` reads **live state at run time** — it shifts *when* the callback looks, not *what* it sees. If you need the value *as it was* N ms ago (trails, ghosts, delayed playback), use [`useReplayRefSignal`](api.md#usereplayrefsignalt-source-ms-snapshot) instead — see [Patterns — Time-shifted signals](patterns.md#time-shifted-signals--usereplayrefsignal).
 
 ---
 

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -16,6 +16,7 @@
 - [Filtered renders at a threshold](#filtered-renders-at-a-threshold)
 - [Module-scope signals and debounced consumers](#module-scope-signals-and-debounced-consumers)
 - [Shared pulse via provider — one timer, many components](#shared-pulse-via-provider--one-timer-many-components)
+- [Time-shifted signals — `useReplayRefSignal`](#time-shifted-signals--usereplayrefsignal)
 
 ---
 
@@ -853,3 +854,46 @@ Mount fifty `<RelativeTime />` cells inside a `<NowProvider>`; you get fifty sub
 The same shape composes at any cadence: a `<TickProvider rate="60fps">` for animation work, a `<HeartbeatProvider rate="30000ms">` for connection pings, a `<NowProvider rate="60000ms">` for relative timestamps. One timer per cadence, regardless of how many consumers attach.
 
 > **Don't put the pulse signal inside a persisted or broadcasted store.** The pulse value is `performance.now()` — bound to this document's `performance.timeOrigin` and meaningless to serialize or transport. Provide it adjacent to such stores instead. See [pulse.md → What pulse can't compose with](pulse.md#what-pulse-cant-compose-with).
+
+---
+
+## Time-shifted signals — `useReplayRefSignal`
+
+A node ghost that trails its node by 300 ms, an afterimage following a drag, delayed playback of a live feed — these all need the value *as it was* N ms ago, retracing every intermediate step. [`useReplayRefSignal`](api.md#usereplayrefsignalt-source-ms-snapshot) gives you that as a derived signal: the source's timeline, shifted.
+
+```tsx
+import {
+  useRefSignal,
+  useReplayRefSignal,
+  useRefSignalEffect,
+} from 'react-refsignal';
+
+function DraggableNodeWithGhost({ ctx }: { ctx: CanvasRenderingContext2D }) {
+  const pos = useRefSignal({ x: 0, y: 0 });
+  // The ghost runs 300 ms behind. The snapshot ({ ...p }) is required here
+  // because `pos` is mutated in place below — without it the queue would hold
+  // references to one live object and the ghost would ride on the node.
+  const ghost = useReplayRefSignal(pos, 300, (p) => ({ ...p }));
+
+  useRefSignalEffect(() => {
+    drawNode(ctx, pos.current.x, pos.current.y);
+  }, [pos], { frame: true });
+
+  useRefSignalEffect(() => {
+    drawGhost(ctx, ghost.current.x, ghost.current.y);
+  }, [ghost], { frame: true });
+
+  const onPointerMove = (e: React.PointerEvent) => {
+    pos.current.x = e.clientX; // hot path: mutate + notify, no allocation
+    pos.current.y = e.clientY;
+    pos.notify();
+  };
+  // …
+}
+```
+
+Note what the ghost effect is: **exactly the node effect, pointed at a different signal**. That's the design — the replayed signal is a regular signal, so every consumer picks its own consumption timing downstream (`frame` for canvas, `throttle` for a UI mirror, none to observe every replayed value), and one replay line can feed any number of consumers.
+
+Outside React, [`createReplayRefSignal`](api.md#createreplayrefsignalt-source-ms-snapshot) is the same primitive with `.dispose()`.
+
+**Don't confuse this with the `{ delayed: N }` timing option.** `delayed` shifts *when* a callback runs — it still reads live state at run time ("the present, late"). A replay shifts *what you see* ("the past, on time"). Reaching for delay to build a trail is the classic trap: the effect fires late but reads `pos.current`, and the ghost teleports onto the node.

--- a/src/hooks/useRefSignalEffect.test.ts
+++ b/src/hooks/useRefSignalEffect.test.ts
@@ -200,6 +200,35 @@ describe('useRefSignalEffect — timing options', () => {
     expect(effect).toHaveBeenCalledTimes(2); // one run after quiet
   });
 
+  it('delayed: fires once N ms after the first signal fire of a burst, reading live state', () => {
+    const observed: number[] = [];
+    const { result } = renderHook(() => {
+      const signal = useRefSignal(0);
+      useRefSignalEffect(
+        () => {
+          observed.push(signal.current);
+        },
+        [signal],
+        { delayed: 100, skipMount: true },
+      );
+      return signal;
+    });
+
+    act(() => {
+      result.current.update(1);
+    });
+    act(() => {
+      jest.advanceTimersByTime(50);
+      result.current.update(2); // burst continues — flush still due at +100 from the first fire
+    });
+    expect(observed).toEqual([]);
+
+    act(() => {
+      jest.advanceTimersByTime(50); // 100ms after the FIRST fire
+    });
+    expect(observed).toEqual([2]); // one run, reading the live (latest) value
+  });
+
   it('frame: signal fires collapse into one effect run per frame', () => {
     const raf = setupRafMock();
     const effect = jest.fn();

--- a/src/hooks/useReplayRefSignal.test.ts
+++ b/src/hooks/useReplayRefSignal.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, StrictMode } from 'react';
+import { renderHook } from '../test-utils/renderHook';
+import { useRefSignal } from './useRefSignal';
+import { useReplayRefSignal } from './useReplayRefSignal';
+
+describe('useReplayRefSignal', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    // Drive performance.now() from the fake-timer clock so due-time math
+    // advances with jest.advanceTimersByTime.
+    jest.spyOn(performance, 'now').mockImplementation(() => jest.now());
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  function mountReplay(ms = 100) {
+    return renderHook(() => {
+      const source = useRefSignal(0);
+      const replayed = useReplayRefSignal(source, ms);
+      return { source, replayed };
+    });
+  }
+
+  it('starts at the source current value and follows it ms behind', () => {
+    const { result } = mountReplay(100);
+
+    expect(result.current.replayed.current).toBe(0);
+
+    act(() => {
+      result.current.source.update(1);
+    });
+    expect(result.current.replayed.current).toBe(0); // not due yet
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    expect(result.current.replayed.current).toBe(1);
+  });
+
+  it('returns a stable signal across re-renders', () => {
+    const { result, rerender } = mountReplay();
+
+    const first = result.current.replayed;
+    rerender();
+    expect(result.current.replayed).toBe(first);
+  });
+
+  it('stops following the source on unmount', () => {
+    const { result, unmount } = mountReplay(100);
+    const { source, replayed } = result.current;
+
+    act(() => {
+      source.update(1);
+    });
+    unmount();
+
+    expect(jest.getTimerCount()).toBe(0); // pending timer cleared
+
+    act(() => {
+      source.update(2);
+      jest.advanceTimersByTime(500);
+    });
+    expect(replayed.current).toBe(0); // never emitted after unmount
+  });
+
+  it('applies the snapshot at enqueue time for in-place-mutated objects', () => {
+    const { result } = renderHook(() => {
+      const source = useRefSignal({ x: 0 });
+      const replayed = useReplayRefSignal(source, 100, (p) => ({ ...p }));
+      return { source, replayed };
+    });
+
+    act(() => {
+      result.current.source.current.x = 1;
+      result.current.source.notify(); // hot-path idiom: mutate + notify
+      result.current.source.current.x = 2; // mutate again before due
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    expect(result.current.replayed.current.x).toBe(1); // the past, not the present
+    expect(result.current.replayed.current).not.toBe(
+      result.current.source.current,
+    );
+  });
+
+  it('keeps following the source across the StrictMode mount cycle', () => {
+    const { result } = renderHook(
+      () => {
+        const source = useRefSignal(0);
+        const replayed = useReplayRefSignal(source, 100);
+        return { source, replayed };
+      },
+      { wrapper: StrictMode },
+    );
+
+    act(() => {
+      result.current.source.update(1);
+    });
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    expect(result.current.replayed.current).toBe(1); // re-attached after the simulated remount
+  });
+
+  it('emits each replayed value exactly once under StrictMode (no double subscription)', () => {
+    const seen: number[] = [];
+
+    const { result } = renderHook(
+      () => {
+        const source = useRefSignal(0);
+        const replayed = useReplayRefSignal(source, 100);
+        return { source, replayed };
+      },
+      { wrapper: StrictMode },
+    );
+
+    result.current.replayed.subscribe((v) => seen.push(v));
+
+    act(() => {
+      result.current.source.update(1);
+    });
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    expect(seen).toEqual([1]); // once, not twice
+  });
+});

--- a/src/hooks/useReplayRefSignal.ts
+++ b/src/hooks/useReplayRefSignal.ts
@@ -1,0 +1,71 @@
+import { useEffect } from 'react';
+import type { ReadonlyRefSignal } from '../refsignal';
+import { attachReplay } from '../replay';
+import { useRefSignal } from './useRefSignal';
+
+/**
+ * React hook companion to {@link createReplayRefSignal} — a read-only signal
+ * that follows `source` exactly `ms` milliseconds behind, retracing every
+ * update in order.
+ *
+ * @see [Patterns — Time-shifted signals](https://github.com/jav974/react-refsignal/blob/main/docs/patterns.md#time-shifted-signals--usereplayrefsignal)
+ *
+ * The replayed signal is stable for the component lifetime and is torn down
+ * on unmount — React owns the lifetime, so no `.dispose()` is exposed (same
+ * contract as {@link useRefSignalMemo}). `source`, `ms`, and `snapshot` are
+ * captured at mount time, mirroring the mount-time-options convention of
+ * {@link useRefSignal} and {@link usePulseRefSignal}.
+ *
+ * Consume it like any other signal — the body is the exact code you would
+ * write against the live source, pointed at a different timeline:
+ *
+ * **`snapshot` is required for object signals mutated in place** (the
+ * `.current.x = …; .notify()` hot-path idiom) — without it the queue holds
+ * references to one live object and every replayed emission shows the
+ * present, not the past. Immutably-updated signals and primitives don't need
+ * it.
+ *
+ * Want an effect to simply run N ms *after* a change, reading live state?
+ * That's not a replay — use the `{ delayed: N }` timing option instead.
+ *
+ * @param source The signal to follow.
+ * @param ms How far behind the source the replayed signal runs, in milliseconds.
+ * @param snapshot Captures the value at enqueue time. Defaults to identity —
+ *   pass e.g. `p => ({ ...p })` for objects mutated in place.
+ *
+ * @example
+ * // Ghost cursor trailing the live cursor by 300 ms
+ * const cursor = useRefSignal({ x: 0, y: 0 });
+ * const ghost = useReplayRefSignal(cursor, 300, (p) => ({ ...p }));
+ *
+ * useRefSignalEffect(() => {
+ *   drawGhost(ctx, ghost.current.x, ghost.current.y);
+ * }, [ghost], { frame: true });
+ *
+ * @example
+ * // Each consumer picks its own consumption timing downstream
+ * const delayedPrice = useReplayRefSignal(price, 5000);
+ * useRefSignalEffect(log, [delayedPrice]);                   // every replayed value
+ * useRefSignalRender([delayedPrice], { throttle: 200 });     // cheap UI mirror
+ */
+export function useReplayRefSignal<T>(
+  source: ReadonlyRefSignal<T>,
+  ms: number,
+  snapshot: (value: T) => T = (v) => v,
+): ReadonlyRefSignal<T> {
+  const sourceName = source.getDebugName();
+  const replayed = useRefSignal(
+    snapshot(source.current),
+    sourceName ? `${sourceName}.replay(${String(ms)}ms)` : undefined,
+  );
+
+  // The replay engine lives in the effect so it detaches/re-attaches across
+  // React's StrictMode mount cycle — the signal shell above stays stable.
+  useEffect(
+    () => attachReplay(source, replayed, ms, snapshot),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- source/ms/snapshot are mount-time options; replayed is stable for the component lifetime
+    [],
+  );
+
+  return replayed;
+}

--- a/src/hooks/useWatchArgs.ts
+++ b/src/hooks/useWatchArgs.ts
@@ -26,7 +26,7 @@ export function useWatchArgs(options?: WatchOptions) {
   trackSignalsRef.current = options?.trackSignals;
 
   // eslint-disable-next-line @typescript-eslint/no-deprecated -- intentional: forwards the legacy `rAF` alias to downstream timing logic.
-  const { throttle, debounce, maxWait, frame, rAF } = options ?? {};
+  const { throttle, debounce, maxWait, delayed, frame, rAF } = options ?? {};
 
   const watchOptions = useMemo(
     (): WatchOptions =>
@@ -34,13 +34,14 @@ export function useWatchArgs(options?: WatchOptions) {
         throttle,
         debounce,
         maxWait,
+        delayed,
         frame,
         rAF,
         trackSignals: trackSignalsRef.current
           ? () => trackSignalsRef.current?.() ?? []
           : undefined,
       }) as WatchOptions,
-    [throttle, debounce, maxWait, frame, rAF],
+    [throttle, debounce, maxWait, delayed, frame, rAF],
   );
 
   return { filterRef, watchOptions };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export * from './hooks/useRefSignalMemo';
 export * from './hooks/useRefSignalRender';
 export * from './hooks/useRefSignalFollow';
 export * from './hooks/usePulseRefSignal';
+export * from './hooks/useReplayRefSignal';
 export type {
   Listener,
   RefSignal,
@@ -32,6 +33,7 @@ export {
 } from './refsignal';
 export { createPulseRefSignal } from './pulse';
 export type { PulseRate, PulseRefSignal } from './pulse';
+export { createReplayRefSignal } from './replay';
 // Deprecated factory re-exported for backward compatibility.
 export {
   // eslint-disable-next-line @typescript-eslint/no-deprecated

--- a/src/replay.test.ts
+++ b/src/replay.test.ts
@@ -1,0 +1,234 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { createRefSignal } from './refsignal';
+import { createReplayRefSignal } from './replay';
+
+describe('createReplayRefSignal', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    // Drive performance.now() from the fake-timer clock so due-time math
+    // advances with jest.advanceTimersByTime.
+    jest.spyOn(performance, 'now').mockImplementation(() => jest.now());
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('starts at the source current value', () => {
+    const source = createRefSignal(42);
+    const replayed = createReplayRefSignal(source, 100);
+
+    expect(replayed.current).toBe(42);
+
+    replayed.dispose();
+    source.dispose();
+  });
+
+  it('holds the previous value until ms elapses, then emits', () => {
+    const source = createRefSignal(0);
+    const replayed = createReplayRefSignal(source, 100);
+
+    source.update(1);
+    expect(replayed.current).toBe(0); // not due yet
+
+    jest.advanceTimersByTime(99);
+    expect(replayed.current).toBe(0); // still not due
+
+    jest.advanceTimersByTime(1);
+    expect(replayed.current).toBe(1); // due at exactly +100
+
+    replayed.dispose();
+    source.dispose();
+  });
+
+  it('replays every update in order, preserving relative spacing', () => {
+    const source = createRefSignal(0);
+    const replayed = createReplayRefSignal(source, 100);
+    const seen: number[] = [];
+    replayed.subscribe((v) => seen.push(v));
+
+    source.update(1); // due at 100
+    jest.advanceTimersByTime(30);
+    source.update(2); // due at 130
+    jest.advanceTimersByTime(30);
+    source.update(3); // due at 160
+
+    jest.advanceTimersByTime(40); // t=100
+    expect(seen).toEqual([1]);
+    jest.advanceTimersByTime(30); // t=130
+    expect(seen).toEqual([1, 2]);
+    jest.advanceTimersByTime(30); // t=160
+    expect(seen).toEqual([1, 2, 3]);
+
+    replayed.dispose();
+    source.dispose();
+  });
+
+  it('drains all overdue entries in one pass when the timer fires late', () => {
+    const source = createRefSignal(0);
+    const replayed = createReplayRefSignal(source, 100);
+    const seen: number[] = [];
+    replayed.subscribe((v) => seen.push(v));
+
+    source.update(1); // due at 100
+    jest.advanceTimersByTime(10);
+    source.update(2); // due at 110
+
+    // jsdom fake timers fire the armed timer at +100; both entries are due
+    // by the time we jump far past them.
+    jest.advanceTimersByTime(500);
+    expect(seen).toEqual([1, 2]);
+    expect(replayed.current).toBe(2);
+
+    replayed.dispose();
+    source.dispose();
+  });
+
+  it('snapshot captures in-place-mutated objects at enqueue time', () => {
+    const source = createRefSignal({ x: 0 });
+    const replayed = createReplayRefSignal(source, 100, (p) => ({ ...p }));
+
+    source.current.x = 1;
+    source.notify(); // hot-path idiom: mutate + notify
+    source.current.x = 2;
+    source.notify();
+
+    jest.advanceTimersByTime(100);
+    // Live object says 2, but the replayed signal shows the past as it was.
+    expect(source.current.x).toBe(2);
+    expect(replayed.current.x).toBe(2); // both entries due — last one wins
+    expect(replayed.current).not.toBe(source.current); // distinct snapshot
+
+    replayed.dispose();
+    source.dispose();
+  });
+
+  it('without snapshot, in-place mutation leaks the present (documented footgun)', () => {
+    const source = createRefSignal({ x: 0 });
+    const replayed = createReplayRefSignal(source, 100); // identity capture
+
+    source.current.x = 1;
+    source.notify();
+    source.current.x = 99; // mutate again before the entry is due
+
+    jest.advanceTimersByTime(100);
+    expect(replayed.current.x).toBe(99); // queue held a live reference
+
+    replayed.dispose();
+    source.dispose();
+  });
+
+  it('keeps no timer armed while the source is quiet', () => {
+    const source = createRefSignal(0);
+    const replayed = createReplayRefSignal(source, 100);
+
+    expect(jest.getTimerCount()).toBe(0); // quiet from creation
+
+    source.update(1);
+    expect(jest.getTimerCount()).toBe(1); // one armed timer
+
+    jest.advanceTimersByTime(100);
+    expect(jest.getTimerCount()).toBe(0); // queue drained — idle again
+
+    replayed.dispose();
+    source.dispose();
+  });
+
+  it('arms at most one timer for a burst', () => {
+    const source = createRefSignal(0);
+    const replayed = createReplayRefSignal(source, 100);
+
+    source.update(1);
+    source.update(2);
+    source.update(3);
+    expect(jest.getTimerCount()).toBe(1);
+
+    replayed.dispose();
+    source.dispose();
+  });
+
+  it('dispose() cancels pending work and stops following the source', () => {
+    const source = createRefSignal(0);
+    const replayed = createReplayRefSignal(source, 100);
+    const seen: number[] = [];
+    replayed.subscribe((v) => seen.push(v));
+
+    source.update(1);
+    replayed.dispose();
+
+    expect(jest.getTimerCount()).toBe(0); // pending timer cleared
+
+    source.update(2); // no longer followed
+    jest.advanceTimersByTime(500);
+    expect(seen).toEqual([]);
+    expect(replayed.current).toBe(0);
+
+    source.dispose();
+  });
+
+  it('derives a devtools-style debug name from the source when available', () => {
+    // Without a devtools adapter getDebugName() is undefined — the replayed
+    // signal must not throw and simply stays unnamed.
+    const source = createRefSignal(0, 'price');
+    const replayed = createReplayRefSignal(source, 50);
+    expect(replayed.getDebugName()).toBeUndefined();
+
+    replayed.dispose();
+    source.dispose();
+  });
+
+  it('throws on a negative or non-finite delay', () => {
+    const source = createRefSignal(0);
+
+    expect(() => createReplayRefSignal(source, -1)).toThrow(
+      /Invalid replay delay/,
+    );
+    expect(() => createReplayRefSignal(source, NaN)).toThrow(
+      /Invalid replay delay/,
+    );
+    expect(() => createReplayRefSignal(source, Infinity)).toThrow(
+      /Invalid replay delay/,
+    );
+
+    source.dispose();
+  });
+
+  it('ms = 0 emits on the next timer tick', () => {
+    const source = createRefSignal(0);
+    const replayed = createReplayRefSignal(source, 0);
+
+    source.update(1);
+    expect(replayed.current).toBe(0); // still async — never synchronous
+
+    jest.advanceTimersByTime(0);
+    expect(replayed.current).toBe(1);
+
+    replayed.dispose();
+    source.dispose();
+  });
+
+  it('a replayed.update subscriber writing back to the source cannot deadlock or double-arm', () => {
+    const source = createRefSignal(0);
+    const replayed = createReplayRefSignal(source, 100);
+
+    // Feedback loop: every replayed emission writes source again (bounded).
+    replayed.subscribe((v) => {
+      if (v < 3) source.update(v + 10);
+    });
+
+    source.update(1); // due at 100
+    jest.advanceTimersByTime(100); // emits 1 → subscriber writes 11 (due at 200)
+    expect(replayed.current).toBe(1);
+    expect(jest.getTimerCount()).toBe(1); // exactly one re-armed timer
+
+    jest.advanceTimersByTime(100); // emits 11 → subscriber stops (11 >= 3)
+    expect(replayed.current).toBe(11);
+    expect(jest.getTimerCount()).toBe(0);
+
+    replayed.dispose();
+    source.dispose();
+  });
+});

--- a/src/replay.ts
+++ b/src/replay.ts
@@ -1,0 +1,154 @@
+/**
+ * `createReplayRefSignal` — a derived signal that replays its source's value
+ * timeline N milliseconds later.
+ *
+ * This is the *time-shifted value* primitive: the output is what the source
+ * **was** N ms ago, retracing every update in order. It is intentionally a
+ * signal→signal transform — timing options like `{ delayed: N }` can shift
+ * *when* a callback runs, but the callback still reads live state; only a
+ * signal can carry a shifted timeline to any consumer (effects, renders,
+ * memos) unchanged.
+ */
+
+import {
+  createRefSignal,
+  watch,
+  type ReadonlyRefSignal,
+  type RefSignal,
+} from './refsignal';
+
+/**
+ * @internal
+ *
+ * The replay engine shared by {@link createReplayRefSignal} and
+ * `useReplayRefSignal`: follows `source` and re-emits each captured value on
+ * `target` once its due time arrives. Returns a detach function that stops
+ * following, cancels the pending timer, and clears the queue — mirroring the
+ * `attachSignalBroadcast` / `attachSignalPersist` attach-returns-cleanup
+ * convention so React hooks can own the lifetime via `useEffect`.
+ *
+ * Scheduling: a single `setTimeout` stays armed for the head entry's due time
+ * — at most one timer exists at a time, and none while the source is quiet.
+ * A late fire (busy event loop) drains everything that became due in the
+ * meantime, so correctness holds under pressure.
+ */
+export function attachReplay<T>(
+  source: ReadonlyRefSignal<T>,
+  target: RefSignal<T>,
+  ms: number,
+  snapshot: (value: T) => T,
+): () => void {
+  if (!Number.isFinite(ms) || ms < 0) {
+    throw new Error(
+      `[refsignal] Invalid replay delay: ${String(ms)}. Must be a non-negative finite number of milliseconds.`,
+    );
+  }
+
+  const queue: { t: number; value: T }[] = [];
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  // Emit every due entry, then keep a timer armed for the next one.
+  const drain = () => {
+    timer = null;
+    const now = performance.now();
+    let head = queue[0];
+    while (head !== undefined && head.t <= now) {
+      queue.shift();
+      target.update(head.value);
+      head = queue[0];
+    }
+    scheduleNext();
+  };
+
+  // One timer at a time, armed only while the queue is non-empty.
+  const scheduleNext = () => {
+    const head = queue[0];
+    if (timer === null && head !== undefined) {
+      timer = setTimeout(drain, head.t - performance.now());
+    }
+  };
+
+  // Enqueue — capture every source fire, stamped with its due time.
+  // Re-entrancy is safe by construction: if a `target.update()` subscriber
+  // synchronously writes back to the source, the fresh entry gets
+  // `t = now + ms > now` so it can never drain in the same pass, and the
+  // `timer === null` guard prevents double-arming.
+  const stopWatching = watch(source, (value) => {
+    queue.push({ t: performance.now() + ms, value: snapshot(value) });
+    scheduleNext();
+  });
+
+  return () => {
+    stopWatching();
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    queue.length = 0;
+  };
+}
+
+/**
+ * Creates a read-only signal that follows `source` exactly `ms` milliseconds
+ * behind — every source update is captured and re-emitted on the replayed
+ * signal once its due time arrives, preserving order and relative spacing.
+ *
+ * Consumer code is identical to consuming the live source — point it at a
+ * different signal and choose any consumption timing (`frame`, `throttle`,
+ * `debounce`, none) downstream. Each due entry is an individual update, so an
+ * untimed subscriber observes every replayed value.
+ *
+ * **`snapshot` is required for object signals mutated in place** (the
+ * `.current.x = …; .notify()` hot-path idiom). Without it the internal queue
+ * holds N references to the same live object and every replayed emission
+ * shows the present, not the past. Signals updated immutably via `.update()`
+ * (and all primitives) don't need it — the default identity capture is
+ * correct and allocation-free.
+ *
+ * Emissions fire at their due moment via a single armed timer — at most one
+ * timer exists at a time, and none while the source is quiet. Inside React
+ * components prefer `useReplayRefSignal`, which ties the lifetime to the
+ * component. Outside React, call `.dispose()` to stop following the source
+ * and release subscribers.
+ *
+ * Want a callback to simply run N ms *after* a change, reading live state?
+ * That's not a replay — use the `{ delayed: N }` timing option instead.
+ *
+ * @param source The signal to follow.
+ * @param ms How far behind the source the replayed signal runs, in milliseconds.
+ * @param snapshot Captures the value at enqueue time. Defaults to identity —
+ *   pass e.g. `p => ({ ...p })` for objects mutated in place.
+ *
+ * @example
+ * // Ghost cursor trailing the live cursor by 300 ms
+ * const cursor = createRefSignal({ x: 0, y: 0 }, 'cursor');
+ * const ghost = createReplayRefSignal(cursor, 300, (p) => ({ ...p }));
+ * watch(ghost, (p) => drawGhost(p), { frame: true });
+ *
+ * @example
+ * // Delayed playback of a numeric feed — primitives need no snapshot
+ * const price = createRefSignal(0);
+ * const delayedPrice = createReplayRefSignal(price, 5000);
+ * watch(delayedPrice, (v) => updateComparisonChart(v));
+ */
+export function createReplayRefSignal<T>(
+  source: ReadonlyRefSignal<T>,
+  ms: number,
+  snapshot: (value: T) => T = (v) => v,
+): ReadonlyRefSignal<T> & { readonly dispose: () => void } {
+  const sourceName = source.getDebugName();
+  const replayed = createRefSignal(
+    snapshot(source.current),
+    sourceName ? `${sourceName}.replay(${String(ms)}ms)` : undefined,
+  );
+
+  const detach = attachReplay(source, replayed, ms, snapshot);
+
+  const baseDispose = replayed.dispose;
+  return Object.assign(replayed, {
+    dispose: () => {
+      detach();
+      baseDispose();
+    },
+  });
+}

--- a/src/timing.test.ts
+++ b/src/timing.test.ts
@@ -270,6 +270,56 @@ describe('applyTimingOptions', () => {
     expect(fn).toHaveBeenCalledTimes(1);
   });
 
+  it('delayed: is mutually exclusive with the other timing strategies (type-level)', () => {
+    const fn = jest.fn();
+    // @ts-expect-error — delayed cannot combine with frame
+    applyTimingOptions(fn, { delayed: 100, frame: true });
+    // @ts-expect-error — delayed cannot combine with throttle
+    applyTimingOptions(fn, { delayed: 100, throttle: 50 });
+    // @ts-expect-error — delayed cannot combine with debounce
+    applyTimingOptions(fn, { delayed: 100, debounce: 50 });
+    // @ts-expect-error — maxWait requires debounce, not delayed
+    applyTimingOptions(fn, { delayed: 100, maxWait: 500 });
+  });
+
+  it('delayed: fires once exactly N ms after the first call of a burst', () => {
+    const fn = jest.fn();
+    const wrapper = applyTimingOptions(fn, { delayed: 100 });
+
+    wrapper.call();
+    jest.advanceTimersByTime(50);
+    wrapper.call(); // burst continues — debounce timer resets, maxWait holds
+    jest.advanceTimersByTime(40);
+    wrapper.call();
+    expect(fn).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(10); // 100ms after the FIRST call
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('delayed: a call after the flush opens a new window', () => {
+    const fn = jest.fn();
+    const wrapper = applyTimingOptions(fn, { delayed: 100 });
+
+    wrapper.call();
+    jest.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    wrapper.call();
+    jest.advanceTimersByTime(100);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('delayed: cancel() clears the pending run', () => {
+    const fn = jest.fn();
+    const wrapper = applyTimingOptions(fn, { delayed: 100 });
+
+    wrapper.call();
+    wrapper.cancel();
+    jest.advanceTimersByTime(500);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
   it('frame: returns a rAF wrapper', () => {
     jest.useRealTimers();
     const raf = setupRafMock();

--- a/src/timing.ts
+++ b/src/timing.ts
@@ -17,7 +17,14 @@ import type { ReadonlyRefSignal } from './refsignal';
  * - `{ throttle: N }` — at most one run per N ms (leading + trailing)
  * - `{ debounce: N }` — run after N ms of quiet
  * - `{ debounce: N, maxWait: M }` — debounce with guaranteed flush every M ms
+ * - `{ delayed: N }` — run exactly N ms after the first update of a burst
  * - `{ frame: true }` — one run per animation frame (uses `requestAnimationFrame`)
+ *
+ * `{ delayed: N }` reads **live state at run time** — it shifts *when* the
+ * callback looks, never *what* it sees. It is sugar for
+ * `{ debounce: N, maxWait: N }`. If you need the value *as it was* N ms ago
+ * (trails, ghosts, delayed playback), that is a different feature: see
+ * `createReplayRefSignal` / `useReplayRefSignal`.
  *
  * `rAF: true` is a deprecated alias for `frame: true` and still works.
  */
@@ -26,6 +33,7 @@ export type TimingOptions =
       throttle?: never;
       debounce?: never;
       maxWait?: never;
+      delayed?: never;
       frame?: never;
       rAF?: never;
     }
@@ -33,6 +41,7 @@ export type TimingOptions =
       throttle: number;
       debounce?: never;
       maxWait?: never;
+      delayed?: never;
       frame?: never;
       rAF?: never;
     }
@@ -40,6 +49,7 @@ export type TimingOptions =
       throttle?: never;
       debounce: number;
       maxWait?: number;
+      delayed?: never;
       frame?: never;
       rAF?: never;
     }
@@ -47,6 +57,15 @@ export type TimingOptions =
       throttle?: never;
       debounce?: never;
       maxWait?: never;
+      delayed: number;
+      frame?: never;
+      rAF?: never;
+    }
+  | {
+      throttle?: never;
+      debounce?: never;
+      maxWait?: never;
+      delayed?: never;
       frame: true;
       rAF?: never;
     }
@@ -54,6 +73,7 @@ export type TimingOptions =
       throttle?: never;
       debounce?: never;
       maxWait?: never;
+      delayed?: never;
       frame?: never;
       /** @deprecated Use `frame: true` instead. `rAF` will be removed in a future major version. */
       rAF: true;
@@ -195,16 +215,21 @@ export function applyTimingOptions(
   fn: () => void,
   options: TimingOptions,
 ): TimingWrapper {
-  const { frame, rAF, throttle, debounce, maxWait } = options as {
+  const { frame, rAF, throttle, debounce, maxWait, delayed } = options as {
     frame?: true;
     rAF?: true;
     throttle?: number;
     debounce?: number;
     maxWait?: number;
+    delayed?: number;
   };
   if (frame || rAF) return createRAF(fn);
   if (throttle !== undefined) return createThrottle(fn, throttle);
   if (debounce !== undefined) return createDebounce(fn, debounce, maxWait);
+  // `delayed: N` — run exactly N ms after the first call of a burst.
+  // Sugar for debounce with an equal maxWait: the debounce timer keeps
+  // resetting during the burst, but maxWait guarantees the flush at +N.
+  if (delayed !== undefined) return createDebounce(fn, delayed, delayed);
   return { call: fn, cancel: () => {} };
 }
 


### PR DESCRIPTION
## What

Two features that were hiding under the word "delayed":

### `{ delayed: N }` — deferred run (fresh read)

Run a callback exactly N ms after the **first** fire of a burst, reading live state at run time. It's exact sugar for `{ debounce: N, maxWait: N }` — a combination that already did this but was undiscoverable as an idiom. Now a first-class 5th timing strategy, available on every hook/API that accepts `TimingOptions` (effect, render, memo, watch, store, persist, broadcast).

```ts
useRefSignalEffect(fn, [sig], { delayed: 100 }); // fires once, 100ms after the burst starts
```

### `createReplayRefSignal` / `useReplayRefSignal` — time-shifted value (replay)

A read-only signal that follows its source exactly N ms behind, retracing every update in order — trails, ghosts, delayed playback.

```tsx
const pos = useRefSignal({ x: 0, y: 0 });
const ghost = useReplayRefSignal(pos, 300, (p) => ({ ...p }));

// exactly the live-source effect, pointed at a different timeline
useRefSignalEffect(() => drawGhost(ctx, ghost.current.x, ghost.current.y), [ghost], { frame: true });
```

- **Drain**: one armed `setTimeout` for the head entry's due time — emissions fire at the due moment (not frame-quantized), no timer while the source is quiet, no rAF dependency (node/SSR-safe, keeps progressing in background tabs). Intentionally not configurable: any drain policy would corrupt the "value as it was N ms ago" contract; consumption timing belongs downstream, per consumer.
- **`snapshot` param** (default identity): required for object signals mutated in place (`.current.x = …; .notify()`) — without it the queue holds references to one live object and every emission shows the present. Immutable updates and primitives need nothing.
- **Layering**: framework-agnostic `attachReplay(source, target, ms, snapshot) → detach` engine (mirrors `attachSignalBroadcast`), composed by the `create*` form and attached in a `useEffect` by the hook — so the replay survives StrictMode mount cycles while the returned signal stays stable.

### Why two features, not one option

The timing layer shifts *when* a callback runs — the callback still reads live state. `delayed` = "the present, late". A replay shifts *what you see* = "the past, on time"; that requires value capture, which is only well-defined signal→signal (a `replay:` timing option on `useRefSignalRender` would be unimplementable — the component body reads `.current`). Docs cross-link the two at every touchpoint, including the classic trap called out in patterns.md: reaching for delay to build a trail makes the ghost teleport onto the node.

## Also

- Fixed `useWatchArgs` silently dropping timing keys missing from its rebuild whitelist — `{ delayed }` reached `watch()` but not the React hooks until added there.

## Tests

20 new tests (711 total): due-time precision, emit order, snapshot footgun both directions, idle-drain (`jest.getTimerCount()` asserts zero timers while quiet / one during a burst), dispose, feedback-loop re-entrancy, StrictMode re-attach + no-double-subscription, and `@ts-expect-error` type-level exclusivity (`{ delayed: 100, frame: true }` is a compile error).

`tsc` ✓ · `eslint` ✓ · 711/711 ✓ · `tsup` build ✓ · bundle 4.12 kB within size-limit ✓