### PR TITLE
fix: harden JS-caller paths in useRefSignalStore + readonly isHydrated

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -796,7 +796,7 @@ const store = useUserContext({ renderOn: ALL });
 // equivalent: useUserContext({ renderOn: 'all' })
 ```
 
-Passing a non-signal key in `renderOn` is a TypeScript error.
+Passing a non-signal key in `renderOn` is a TypeScript error. Plain JavaScript callers bypass that check — the key is silently ignored and never triggers a re-render, so a dev-mode console warning fires instead.
 
 **Timing and filter options** — all [`EffectOptions`](#effectoptions) fields are accepted alongside `renderOn` and `unwrap`. `filter` is upgraded to receive the store snapshot directly (see [`SignalStoreOptions`](#signalstoreoptionststore)):
 
@@ -826,7 +826,7 @@ const { name, setName, score, setScore, sessionId } = useUserContext({
 // sessionId: string (passthrough)
 ```
 
-> **Warning:** `unwrap: true` without `renderOn` snapshots `.current` values at mount and never refreshes them. The component reads stale values silently. Always combine `unwrap: true` with a `renderOn` list when the unwrapped values are used in JSX.
+> **Warning:** `unwrap: true` without `renderOn` is a TypeScript error — the options type requires `renderOn` when unwrapping. Plain JavaScript callers bypass that check: the hook still runs, but nothing subscribes, so the component never re-renders and JSX shows stale values (the proxy reads live `.current`, so event handlers see fresh data — JSX doesn't). A dev-mode console warning fires in this case. Always combine `unwrap: true` with a `renderOn` list.
 
 ---
 
@@ -1030,7 +1030,7 @@ const { GameProvider, useGameContext } = createRefSignalContext(
 
 // Hook variant — returns { isHydrated, flush, clear }
 const { isHydrated, flush, clear } = usePersist(store, { key: 'game', keys: ['score', 'level'] });
-// isHydrated: RefSignal<boolean>    — true once storage read resolves
+// isHydrated: ReadonlyRefSignal<boolean> — true once storage read resolves
 // flush():    () => Promise<void>    — write current state immediately; awaitable; rejects on adapter failure
 // clear():    () => Promise<void>    — wipe storage + reset all signals to defaults
 ```

--- a/docs/decision-tree.md
+++ b/docs/decision-tree.md
@@ -199,7 +199,7 @@ flowchart TD
     Q3 -->|All signals| G["renderOn: ALL"]
 
     F & G --> Q4{"Want plain values + auto-generated setters instead of signal refs?"}
-    Q4 -->|Yes| H["unwrap: true\nrequires renderOn — type error without it"]
+    Q4 -->|Yes| H["unwrap: true\nrequires renderOn — type error without it\n(plain JS: dev-mode warning, JSX never refreshes)"]
     Q4 -->|No| I["Read signal.current in JSX"]
 ```
 
@@ -269,7 +269,7 @@ flowchart TD
     Q1 -->|Entire store| Q2{"Provider lifecycle?"}
 
     Q2 -->|"Factory — lives for app lifetime"| B["broadcast(factory, options) wrapper"]
-    Q2 -->|Provider mounts and unmounts| C["useBroadcast(store, options)\nReturns { isBroadcaster: RefSignal<boolean> }"]
+    Q2 -->|Provider mounts and unmounts| C["useBroadcast(store, options)\nReturns { isBroadcaster, isStableBroadcaster }\n(both ReadonlyRefSignal<boolean>)"]
 
     A & B & C --> Q3{"How should tabs coordinate?"}
     Q3 -->|"All tabs send and receive equally — default"| D["mode: 'many-to-many'"]

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -593,7 +593,7 @@ function LeaderPoller({
   userId,
 }: {
   messages: RefSignal<MessagesData | undefined>;
-  isBroadcaster: RefSignal<boolean>;
+  isBroadcaster: ReadonlyRefSignal<boolean>;
   userId: string;
 }) {
   // Re-render this leaf when leadership flips so the query re-evaluates.

--- a/docs/persist.md
+++ b/docs/persist.md
@@ -109,7 +109,7 @@ All three signals are stored under a single key as one JSON blob. When the page 
 Use `usePersist` when your Provider needs to be a full React component — for example, when the storage key is derived from a prop (`userId`, `roomId`, route param), when you want to gate rendering until hydration completes, or when you need to combine persistence with other hooks such as data fetching, auth, or a WebSocket subscription. The hook ties persistence to the Provider's lifetime: subscriptions are created on mount and torn down on unmount, so no writes occur after the component leaves the tree.
 
 Returns `{ isHydrated, flush, clear }`:
-- `isHydrated` — a `RefSignal<boolean>` that becomes `true` once hydration completes. Use it to gate rendering.
+- `isHydrated` — a `ReadonlyRefSignal<boolean>` that becomes `true` once hydration completes. Use it to gate rendering. The hook owns the write side — consumers only read or subscribe.
 - `flush` — writes the current store state to storage immediately, bypassing `filter` and any pending throttle/debounce timer. Returns a `Promise<void>` that resolves when the write completes; rejects if the storage adapter throws. Fire-and-forget is still valid — the returned promise is only interesting for callers that need to await completion (e.g., before navigation) or detect write failures.
 - `clear` — removes the storage key and resets all persisted signals to their defaults. Cancels pending timers and suppresses the save-on-reset cycle so storage stays empty. Returns a `Promise<void>` that resolves once the storage write is complete.
 
@@ -547,7 +547,7 @@ function usePersist<TStore>(
   store: TStore,
   options: PersistOptions<TStore>,
 ): {
-  isHydrated: RefSignal<boolean>;
+  isHydrated: ReadonlyRefSignal<boolean>;
   flush: () => Promise<void>;
   clear: () => Promise<void>;
 }

--- a/src/persist/usePersist.ts
+++ b/src/persist/usePersist.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react';
-import type { RefSignal } from '../refsignal';
+import type { ReadonlyRefSignal } from '../refsignal';
 import { useRefSignal } from '../hooks/useRefSignal';
 import { PersistOptions } from './types';
 import { setupPersist } from './persist';
@@ -13,8 +13,9 @@ const noopAsync = async () => {};
  * @see [Decision Tree §9 — Persistence](https://github.com/jav974/react-refsignal/blob/main/docs/decision-tree.md#9-persistence)
  *
  * Returns `{ isHydrated, flush, clear }`:
- * - `isHydrated` — a `RefSignal<boolean>` that becomes `true` once hydration completes.
- *   Use it to gate rendering until stored values are loaded.
+ * - `isHydrated` — a `ReadonlyRefSignal<boolean>` that becomes `true` once hydration
+ *   completes. Use it to gate rendering until stored values are loaded. The hook owns
+ *   the write side — consumers only read or subscribe.
  * - `flush` — writes the current store state to storage immediately, bypassing
  *   `filter` and any pending throttle/debounce timer. Returns a `Promise<void>`
  *   that resolves when the write completes; rejects on adapter failure.
@@ -35,7 +36,7 @@ export function usePersist<TStore extends object>(
   store: TStore,
   options: PersistOptions<TStore>,
 ): {
-  isHydrated: RefSignal<boolean>;
+  isHydrated: ReadonlyRefSignal<boolean>;
   flush: () => Promise<void>;
   clear: () => Promise<void>;
 } {

--- a/src/store/createRefSignalStore.test.tsx
+++ b/src/store/createRefSignalStore.test.tsx
@@ -6,6 +6,7 @@ import { act } from 'react';
 import { renderHook } from '../test-utils/renderHook';
 import { createRefSignal, watch } from '../refsignal';
 import { createRefSignalStore } from './createRefSignalStore';
+import { type RefSignalKeys } from './useRefSignalStore';
 import {
   useRefSignalStore,
   type SignalStoreOptionsPlain,
@@ -192,6 +193,94 @@ describe('useRefSignalStore — unwrap', () => {
     });
     expect(result.current.tag).toBe('game');
     expect((result.current as Record<string, unknown>).setTag).toBeUndefined();
+  });
+});
+
+describe('useRefSignalStore — unwrap without renderOn (JS callers)', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('warns in development — the type system blocks this, plain JS does not', () => {
+    const store = createRefSignalStore(makeStore);
+    // Cast simulates an untyped JS caller; TS rejects this options shape.
+    renderHook(() =>
+      useRefSignalStore(store, {
+        unwrap: true,
+      } as unknown as SignalStoreOptionsUnwrapped<GameStore>),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('unwrap: true without renderOn'),
+    );
+  });
+
+  it('does not warn when renderOn is provided', () => {
+    mountStoreUnwrapped({ renderOn: ['score'], unwrap: true });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('useRefSignalStore — renderOn key validation (JS callers)', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  // The warning dedupe set is module-global, so each test uses a distinct
+  // bad key to stay independent of execution order.
+
+  it('warns when a renderOn key does not resolve to a signal', () => {
+    const store = createRefSignalStore(makeStore);
+    renderHook(() =>
+      useRefSignalStore(store, {
+        // Cast simulates an untyped JS caller; TS rejects unknown keys.
+        renderOn: ['scoer'] as unknown as Array<RefSignalKeys<GameStore>>,
+      }),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('renderOn key "scoer"'),
+    );
+  });
+
+  it('warns for a non-signal store value used as a renderOn key', () => {
+    const store = createRefSignalStore(makeStore);
+    renderHook(() =>
+      useRefSignalStore(store, {
+        renderOn: ['tag'] as unknown as Array<RefSignalKeys<GameStore>>,
+      }),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('renderOn key "tag"'),
+    );
+  });
+
+  it('warns only once per key across re-renders', () => {
+    const store = createRefSignalStore(makeStore);
+    const { rerender } = renderHook(() =>
+      useRefSignalStore(store, {
+        renderOn: ['levle'] as unknown as Array<RefSignalKeys<GameStore>>,
+      }),
+    );
+    rerender();
+    rerender();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not warn for valid signal keys', () => {
+    const store = createRefSignalStore(makeStore);
+    renderHook(() => useRefSignalStore(store, { renderOn: ['score'] }));
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/store/useRefSignalStore.ts
+++ b/src/store/useRefSignalStore.ts
@@ -54,6 +54,13 @@ type BaseStoreOptions<TStore> = TimingOptions & {
   filter?: (store: StoreSnapshot<TStore>) => boolean;
 };
 
+const IS_PRODUCTION =
+  typeof process !== 'undefined' && process.env.NODE_ENV === 'production';
+
+// Dev-warning dedupe — a component re-rendering at frame rate must not flood
+// the console with the same diagnostic. Keyed globally; good enough for dev.
+const warnedRenderOnKeys = new Set<PropertyKey>();
+
 /**
  * Options accepted by `useRefSignalStore`. Shape depends on `unwrap`:
  * - `unwrap: true` (Unwrapped variant) requires `renderOn` — unwrapping
@@ -142,12 +149,43 @@ export function useRefSignalStore<TStore extends object>(
   store: TStore,
   options?: SignalStoreOptions<TStore>,
 ): TStore | UnwrappedStore<TStore> {
+  // TypeScript rejects `unwrap` without `renderOn` at compile time, but plain
+  // JS callers reach here unchecked — and get values that never refresh in JSX.
+  // The cast defeats the union narrowing that makes this state "impossible".
+  const uncheckedOptions = options as
+    | { unwrap?: boolean; renderOn?: unknown }
+    | undefined;
+  if (
+    !IS_PRODUCTION &&
+    uncheckedOptions?.unwrap &&
+    uncheckedOptions.renderOn === undefined
+  ) {
+    console.warn(
+      '[react-refsignal] unwrap: true without renderOn — unwrapped values never trigger a re-render, so JSX will show stale values. Add renderOn (e.g. renderOn: ALL).',
+    );
+  }
+
   // ── Resolve which signals to subscribe to ─────────────────────────────────
   let signals: RefSignal[];
   if (options?.renderOn === 'all') {
     signals = Object.values(store).filter(isRefSignal);
   } else if (options?.renderOn !== undefined) {
-    signals = options.renderOn.map((key) => store[key] as RefSignal);
+    // Same JS-caller gap as the unwrap guard above: TypeScript rejects keys
+    // that aren't signals on the store, but a plain-JS typo reaches here —
+    // and an unresolved key would crash the render-snapshot pass (reading
+    // .lastUpdated on undefined). Filter non-signals out; warn in dev.
+    signals = [];
+    for (const key of options.renderOn) {
+      const value = (store as Record<PropertyKey, unknown>)[key];
+      if (isRefSignal(value)) {
+        signals.push(value);
+      } else if (!IS_PRODUCTION && !warnedRenderOnKeys.has(key)) {
+        warnedRenderOnKeys.add(key);
+        console.warn(
+          `[react-refsignal] renderOn key "${String(key)}" does not resolve to a signal on the store — updates will never trigger a re-render. Check for a typo or a non-signal value.`,
+        );
+      }
+    }
   } else {
     signals = [];
   }


### PR DESCRIPTION
TypeScript guards on the store options don't exist for plain-JS callers. This PR closes the silent (or crashing) gaps and fixes related doc drift.

## Changes

- **`unwrap: true` without `renderOn`** — dev-mode warning. TS rejects the combination; in JS it executes and JSX silently never refreshes.
- **Non-signal `renderOn` keys** — a typo'd key crashed `getSnapshot` (`.lastUpdated` on `undefined`). Non-signals are now filtered out of the subscription list (all builds) with a once-per-key dev warning.
- **`usePersist` `isHydrated`** — narrowed to `ReadonlyRefSignal<boolean>` (type-only; same runtime object), symmetric with `useBroadcast`'s status signals.
- **Docs** — corrected the `unwrap` warning mechanism in api.md (live proxy reads, no re-render — not a mount snapshot), fixed decision-tree's stale `useBroadcast` return shape (missing `isStableBroadcaster`), readonly status signal types in persist.md/patterns.md.

## Tests

6 new tests (warnings, dedupe, no false positives). Full suite: 32 suites, 717 passed.