### PR TITLE
fix: accept ReadonlyRefSignal keys in renderOn

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -366,8 +366,8 @@ Options accepted by `useRefSignalStore`, `createRefSignalContext`, and `createRe
 
 | Option | Type | Description |
 |---|---|---|
-| `renderOn` | `Array<RefSignalKeys<TStore>>` \| `'all'` | Signal keys that trigger a re-render. Omit to never re-render. |
-| `unwrap` | `boolean` | If `true`, returns plain values with auto-generated setters instead of raw signals. Requires `renderOn`. |
+| `renderOn` | `Array<RefSignalKeys<TStore>>` \| `'all'` | Signal keys that trigger a re-render. Accepts both `RefSignal` and `ReadonlyRefSignal` keys (computed / memo signals) — subscribing is a read-side operation. Omit to never re-render. |
+| `unwrap` | `boolean` | If `true`, returns plain values with auto-generated setters instead of raw signals. Readonly signal keys unwrap to their value but get no setter — the value is derived. Requires `renderOn`. |
 | `filter` | `(store: StoreSnapshot<TStore>) => boolean` | Only re-render if this returns `true`. Receives the store snapshot — signals unwrapped to their current values. |
 | `throttle` / `debounce` / `maxWait` / `frame` | — | Same as [`TimingOptions`](#timingoptions). |
 
@@ -407,7 +407,7 @@ const result = useRefSignalMemo(
 - The returned signal can be subscribed to like any other signal.
 - `options` is a [`WatchOptions`](#watchoptions) — timing, filter, and `trackSignals` for dynamic-signal traversal.
 
-Returns a [`ReadonlyRefSignal<T>`](#readonlyrefsignalt) — read-side APIs (`.current`, `.lastUpdated`, `.subscribe`/`.unsubscribe`, `.getDebugName`) only; the write-side APIs (`.update`, `.reset`, `.notify`, `.notifyUpdate`) are hidden. The lifetime is tied to the component, so no `.dispose()` either. Pass it as a dep wherever a `ReadonlyRefSignal` is accepted: `useRefSignalRender`, `useRefSignalEffect`, `useRefSignalMemo`, `useRefSignalFollow`, `createComputedRefSignal`, `watch`, `watchSignals`, and `WatchOptions.trackSignals`.
+Returns a [`ReadonlyRefSignal<T>`](#readonlyrefsignalt) — read-side APIs (`.current`, `.lastUpdated`, `.subscribe`/`.unsubscribe`, `.getDebugName`) only; the write-side APIs (`.update`, `.reset`, `.notify`, `.notifyUpdate`) are hidden. The lifetime is tied to the component, so no `.dispose()` either. Pass it as a dep wherever a `ReadonlyRefSignal` is accepted: `useRefSignalRender`, `useRefSignalEffect`, `useRefSignalMemo`, `useRefSignalFollow`, `createComputedRefSignal`, `watch`, `watchSignals`, and `WatchOptions.trackSignals` — and as a `renderOn` key when placed in a store or context.
 
 ---
 

--- a/src/store/createRefSignalStore.test.tsx
+++ b/src/store/createRefSignalStore.test.tsx
@@ -4,7 +4,13 @@
 import React, { ReactNode } from 'react';
 import { act } from 'react';
 import { renderHook } from '../test-utils/renderHook';
-import { createRefSignal, watch } from '../refsignal';
+import {
+  createRefSignal,
+  createComputedRefSignal,
+  watch,
+  type RefSignal,
+  type ReadonlyRefSignal,
+} from '../refsignal';
 import { createRefSignalStore } from './createRefSignalStore';
 import { type RefSignalKeys } from './useRefSignalStore';
 import {
@@ -281,6 +287,70 @@ describe('useRefSignalStore — renderOn key validation (JS callers)', () => {
     const store = createRefSignalStore(makeStore);
     renderHook(() => useRefSignalStore(store, { renderOn: ['score'] }));
     expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('useRefSignalStore — ReadonlyRefSignal keys in renderOn', () => {
+  type DerivedStore = {
+    count: RefSignal<number>;
+    double: ReadonlyRefSignal<number>;
+  };
+
+  function makeDerivedStore(): DerivedStore {
+    const count = createRefSignal(0);
+    const double = createComputedRefSignal(() => count.current * 2, [count]);
+    return { count, double };
+  }
+
+  it('accepts a readonly signal key and re-renders when the computed fires', () => {
+    const store = makeDerivedStore();
+    let renders = 0;
+    renderHook(() => {
+      renders++;
+      return useRefSignalStore(store, { renderOn: ['double'] });
+    });
+    expect(renders).toBe(1);
+    act(() => {
+      store.count.update(5);
+    });
+    expect(store.double.current).toBe(10);
+    expect(renders).toBe(2);
+  });
+
+  it('unwraps a readonly signal key to its value, with no setter in the type', () => {
+    const store = makeDerivedStore();
+    const { result } = renderHook(() =>
+      useRefSignalStore(store, { renderOn: ['double'], unwrap: true }),
+    );
+    expect(result.current.double).toBe(0);
+    act(() => {
+      store.count.update(3);
+    });
+    expect(result.current.double).toBe(6);
+    // @ts-expect-error — readonly signal keys get no auto-generated setter
+    void result.current.setDouble;
+    // Writable keys still do.
+    expect(typeof result.current.setCount).toBe('function');
+  });
+
+  it('passes the unwrapped readonly value to the store-snapshot filter', () => {
+    const store = makeDerivedStore();
+    let renders = 0;
+    renderHook(() => {
+      renders++;
+      return useRefSignalStore(store, {
+        renderOn: ['double'],
+        filter: (s) => s.double >= 10, // s.double: number — snapshot unwraps readonly signals
+      });
+    });
+    act(() => {
+      store.count.update(2); // double = 4 — filtered out
+    });
+    expect(renders).toBe(1);
+    act(() => {
+      store.count.update(6); // double = 12 — passes
+    });
+    expect(renders).toBe(2);
   });
 });
 

--- a/src/store/useRefSignalStore.ts
+++ b/src/store/useRefSignalStore.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { isRefSignal, RefSignal } from '../refsignal';
+import { isRefSignal, RefSignal, type ReadonlyRefSignal } from '../refsignal';
 import { useRefSignalRender } from '../hooks/useRefSignalRender';
 import type { EffectOptions } from '../hooks/useRefSignalEffect';
 import type { TimingOptions } from '../timing';
@@ -7,36 +7,42 @@ import type { TimingOptions } from '../timing';
 // ─── Shared store types ────────────────────────────────────────────────────────
 
 /**
- * Extracts the keys of a store whose values are RefSignal instances.
+ * Extracts the keys of a store whose values are readable signals —
+ * `RefSignal` or `ReadonlyRefSignal` (computed / memo / followed signals).
+ * Subscribing is a read-side operation, so render-side options accept both.
  * Non-signal values are excluded from the resulting union type.
  *
  * @example
- * type Store = { name: RefSignal<string>; score: RefSignal<number>; sessionId: string }
- * type Keys = RefSignalKeys<Store> // 'name' | 'score'
+ * type Store = { name: RefSignal<string>; upper: ReadonlyRefSignal<string>; sessionId: string }
+ * type Keys = RefSignalKeys<Store> // 'name' | 'upper'
  */
 export type RefSignalKeys<TStore> = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [K in keyof TStore]: TStore[K] extends RefSignal<any> ? K : never;
+  [K in keyof TStore]: TStore[K] extends ReadonlyRefSignal<any> ? K : never;
 }[keyof TStore];
 
 /**
- * Replaces each RefSignal<V> in the store with its inner value V,
- * and generates a `set${Key}` setter for each signal key.
- * Non-signal values are left unchanged. No setter is generated for them.
+ * Replaces each readable signal in the store with its inner value V, and
+ * generates a `set${Key}` setter for each *writable* signal key. Readonly
+ * signal keys (computed / memo) unwrap to their value but get no setter —
+ * the value is derived, so there is nothing valid to set. Non-signal values
+ * are left unchanged.
  *
  * @example
- * type Store = { name: RefSignal<string>; score: RefSignal<number>; sessionId: string }
+ * type Store = { name: RefSignal<string>; upper: ReadonlyRefSignal<string>; sessionId: string }
  * type Unwrapped = UnwrappedStore<Store>
  * // {
  * //   name: string
- * //   score: number
+ * //   upper: string
  * //   sessionId: string
  * //   setName: (value: string) => void
- * //   setScore: (value: number) => void
+ * //   // no setUpper — readonly signals are not writable
  * // }
  */
 export type UnwrappedStore<TStore> = {
-  [K in keyof TStore]: TStore[K] extends RefSignal<infer V> ? V : TStore[K];
+  [K in keyof TStore]: TStore[K] extends ReadonlyRefSignal<infer V>
+    ? V
+    : TStore[K];
 } & {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [K in keyof TStore as TStore[K] extends RefSignal<any>
@@ -45,7 +51,7 @@ export type UnwrappedStore<TStore> = {
 };
 
 export type StoreSnapshot<TStore> = {
-  readonly [K in keyof TStore]: TStore[K] extends RefSignal<infer V>
+  readonly [K in keyof TStore]: TStore[K] extends ReadonlyRefSignal<infer V>
     ? V
     : TStore[K];
 };


### PR DESCRIPTION
`renderOn` rejected keys typed `ReadonlyRefSignal` (computed / memo signals), even though subscribing is a read-side operation and the runtime already supports it (`renderOn: ALL` subscribes to them today). This broke the documented cross-tab notification badge recipe in patterns.md, which doesn't compile on main.

## Changes

Type-only — zero runtime diff:

- **`RefSignalKeys`** matches `ReadonlyRefSignal<any>` — readonly signal keys accepted in `renderOn`
- **`UnwrappedStore`** — readonly keys unwrap to their value, but `set${Key}` is generated only for writable `RefSignal` keys (derived values have nothing valid to set)
- **`StoreSnapshot`** — `filter` snapshots unwrap readonly signals too

## Tests

3 new: renderOn on a computed key re-renders, unwrap exposes value with `@ts-expect-error` on the absent setter, snapshot filter receives the unwrapped value. patterns.md recipe verified to compile. Full suite: 32 suites, 720 passed.