### PR TITLE
feat: store registration in devtools — createRefSignalStore(factory, debugName?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ import { createRefSignalStore, useRefSignalStore, createRefSignal } from 'react-
 const gameStore = createRefSignalStore(() => ({
   score: createRefSignal(0),
   level: createRefSignal(1),
-}));
+}), 'game'); // optional name — groups members in devtools as game.score, game.level
 
 // Outside React — direct access
 gameStore.score.update(42);

--- a/docs/api.md
+++ b/docs/api.md
@@ -29,7 +29,7 @@
 - [`watchSignals(deps, onFire, options?)`](#watchsignalsdeps-onfire-options)
 - [`WatchHandle`](#watchhandle)
 - [`batch(callback, deps?)`](#batchcallback-deps)
-- [`createRefSignalStore<TStore>(factory)`](#createrefsignalstoretstore-factory)
+- [`createRefSignalStore<TStore>(factory, debugName?)`](#createrefsignalstoretstore-factory-debugname)
 - [`useRefSignalStore<TStore>(store, options?)`](#userefsignalstoretstore-store-options)
 - [`createRefSignalContext<TName, TStore>(name, factory)`](#createrefsignalcontexttname-tstore-name-factory)
 - [`createRefSignalContextHook<TStore>(name)`](#createrefsignalcontexthooktstore-name)
@@ -700,9 +700,11 @@ Batches are nestable. If the callback throws, the batch still flushes via `final
 
 ---
 
-### `createRefSignalStore<TStore>(factory)`
+### `createRefSignalStore<TStore>(factory, debugName?)`
 
 Creates a module-scope signal store singleton. The factory is called once immediately — the returned store lives for the application's lifetime. No Provider required.
+
+When [DevTools](#devtools) are active, the store registers itself under `debugName`: the Signals panel groups its members, and anonymous member signals get derived names (`game.score` instead of `signal_3`). Stores without a `debugName` are auto-named (`store_1`). Zero cost in production or when DevTools aren't imported.
 
 Use [`useRefSignalStore`](#userefsignalstoretstore-store-options) to connect the store to React components. Use [`createRefSignalContext`](#createrefsignalcontexttname-tstore-name-factory) instead when you need per-subtree isolation (separate store per Provider mount).
 
@@ -713,7 +715,7 @@ const gameStore = createRefSignalStore(() => ({
   score: createRefSignal(0),
   level: createRefSignal(1),
   tag:   'game', // non-signal passthrough
-}));
+}), 'game'); // DevTools: members appear as game.score, game.level
 
 // Outside React — direct access, no Provider
 gameStore.score.update(42);

--- a/docs/decision-tree.md
+++ b/docs/decision-tree.md
@@ -184,7 +184,7 @@ flowchart TD
 ```mermaid
 flowchart TD
     Q1{"Scope of shared state?"}
-    Q1 -->|"Global singleton — one instance for the whole app"| A["createRefSignalStore(factory)\nReturns the store directly — no Provider"]
+    Q1 -->|"Global singleton — one instance for the whole app"| A["createRefSignalStore(factory, debugName?)\nReturns the store directly — no Provider\ndebugName groups members in devtools"]
     Q1 -->|"Per-subtree — isolated store per Provider mount"| Q2
 
     A --> B["useRefSignalStore(store, options?)\nConnect to a component with opt-in re-renders"]

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -125,7 +125,9 @@ devtools.reset();              // clear all tracking state
 
 Live table of every registered signal. Anonymous signals (created without a debug name) are tagged `(anon)` and given an auto-id like `signal_3`. Click a row to open a detail card with the full value and a "Copy value" button.
 
-Sort by name, subscriber count, or last-updated counter. Filter by name with the search box.
+Signals belonging to a [`createRefSignalStore`](api.md#createrefsignalstoretstore-factory-debugname) render grouped under a collapsible store header. Pass a debug name (`createRefSignalStore(factory, 'game')`) and anonymous members are automatically named `game.score`, `game.level` — one name fixes the whole store. Unnamed stores still group, under an auto-name (`store_1`).
+
+Sort by name, subscriber count, or last-updated counter. Filter by name (store names match too) with the search box.
 
 ### Timeline
 
@@ -250,6 +252,8 @@ const myAdapter: DevToolsAdapter = {
 
 setDevToolsAdapter(myAdapter);
 ```
+
+`registerStore` is an optional adapter method — `createRefSignalStore` calls it (when present) with the store object and its debug name, so adapters can group member signals. Omit it and stores simply aren't grouped.
 
 Importing `react-refsignal/devtools` is **not** required if you ship your own adapter — `setDevToolsAdapter` is exported from the core entry.
 

--- a/src/devtools/adapter.test.ts
+++ b/src/devtools/adapter.test.ts
@@ -498,4 +498,117 @@ describe('DevTools', () => {
       expect(devtools.getEvents().length).toBeLessThanOrEqual(3);
     });
   });
+
+  describe('registerStore', () => {
+    it('renames anonymous member signals to store.key', () => {
+      const score = createRefSignal(0);
+      const level = createRefSignal(1);
+      devtools.registerStore({ score, level }, 'game');
+
+      expect(devtools.getSignalName(score)).toBe('game.score');
+      expect(devtools.getSignalName(level)).toBe('game.level');
+      expect(devtools.getSignalByName('game.score')).toBe(score);
+    });
+
+    it('keeps explicit debug names and tags membership', () => {
+      const score = createRefSignal(0, 'myScore');
+      devtools.registerStore({ score }, 'game');
+
+      expect(devtools.getSignalName(score)).toBe('myScore');
+      const entry = devtools.getAllSignals().find((e) => e.id === 'myScore');
+      expect(entry?.store).toBe('game');
+    });
+
+    it('sets store membership on renamed entries', () => {
+      const score = createRefSignal(0);
+      devtools.registerStore({ score }, 'game');
+
+      const entry = devtools.getAllSignals().find((e) => e.id === 'game.score');
+      expect(entry?.store).toBe('game');
+      expect(entry?.name).toBe('game.score');
+    });
+
+    it('ignores non-signal store values', () => {
+      const score = createRefSignal(0);
+      devtools.registerStore({ score, tag: 'plain' }, 'game');
+
+      const ids = devtools.getAllSignals().map((e) => e.id);
+      expect(ids).toContain('game.score');
+      expect(ids).not.toContain('game.tag');
+    });
+
+    it('auto-names unnamed stores', () => {
+      const a = createRefSignal(0);
+      devtools.registerStore({ a });
+
+      const entry = devtools.getAllSignals().find((e) => e.signal === a);
+      expect(entry?.store).toMatch(/^store_\d+$/);
+      expect(entry?.id).toBe(`${entry?.store ?? ''}.a`);
+    });
+
+    it('suffixes colliding store names', () => {
+      const a = createRefSignal(0);
+      const b = createRefSignal(0);
+      const c = createRefSignal(0);
+      devtools.registerStore({ a }, 'game');
+      devtools.registerStore({ b }, 'game');
+      devtools.registerStore({ c }, 'game'); // third collision walks past #2
+
+      const entryB = devtools.getAllSignals().find((e) => e.signal === b);
+      expect(entryB?.store).toBe('game#2');
+      expect(entryB?.id).toBe('game#2.b');
+      const entryC = devtools.getAllSignals().find((e) => e.signal === c);
+      expect(entryC?.store).toBe('game#3');
+    });
+
+    it('skips devtools-internal member signals', () => {
+      const score = createRefSignal(0);
+      const internal = devtools.createInternal(0);
+      devtools.registerStore({ score, internal }, 'game');
+
+      const ids = devtools.getAllSignals().map((e) => e.id);
+      expect(ids).toContain('game.score');
+      expect(ids).not.toContain('game.internal');
+    });
+
+    it('registers members that were never individually registered', () => {
+      // Simulates a signal created before the adapter was set: full RefSignal
+      // shape, but absent from the registry.
+      const orphan = {
+        current: 0,
+        lastUpdated: 0,
+        subscribe: () => {},
+        unsubscribe: () => {},
+        update: () => {},
+        reset: () => {},
+        notify: () => {},
+        notifyUpdate: () => {},
+      };
+      devtools.registerStore({ orphan }, 'game');
+
+      const ids = devtools.getAllSignals().map((e) => e.id);
+      expect(ids).toContain('game.orphan');
+    });
+
+    it('emits a store:register event with member ids', () => {
+      const score = createRefSignal(0);
+      devtools.registerStore({ score }, 'game');
+
+      const event = devtools
+        .getEvents()
+        .find((e) => e.kind === 'store:register');
+      expect(event).toBeDefined();
+      expect(event?.store).toBe('game');
+      expect(event?.members).toEqual(['game.score']);
+    });
+
+    it('renamed members keep working in trackUpdate attribution', () => {
+      const score = createRefSignal(0);
+      devtools.registerStore({ score }, 'game');
+
+      score.update(5);
+      const last = devtools.getUpdateHistory().at(-1);
+      expect(last?.signalId).toBe('game.score');
+    });
+  });
 });

--- a/src/devtools/adapter.ts
+++ b/src/devtools/adapter.ts
@@ -1,5 +1,6 @@
 import {
   createRefSignal,
+  isRefSignal,
   setDevToolsAdapter,
   type DevToolsAdapter,
   type DevToolsEvent,
@@ -38,6 +39,8 @@ export interface CascadeEdge {
 export interface SignalEntry {
   id: string;
   name?: string;
+  /** Store this signal belongs to — set by `registerStore`, groups the Signals panel. */
+  store?: string;
   signal: RefSignal;
 }
 
@@ -84,6 +87,8 @@ class RefSignalDevTools implements DevToolsAdapter {
   private signalsByName = new Map<string, RefSignal>();
   private signalEntries = new Map<string, SignalEntry>();
   private signalIdCounter = 0;
+  private storeNames = new Set<string>();
+  private storeIdCounter = 0;
   private updateHistory: SignalUpdate[] = [];
   private events: DevToolsEvent[] = [];
   private edges = new Map<string, CascadeEdge>();
@@ -176,6 +181,62 @@ class RefSignalDevTools implements DevToolsAdapter {
 
   getSignalName<T>(signal: RefSignal<T>): string | undefined {
     return this.signals.get(signal as object);
+  }
+
+  /**
+   * Group a store's member signals under one name. Called by
+   * `createRefSignalStore` after the factory runs — core only reports the
+   * fact; all naming policy lives here:
+   * - anonymous members are renamed `storeName.key` (registry id, timeline,
+   *   cascade edges, and `getSignalByName` all pick the new name up)
+   * - explicitly named members keep their name and only gain membership
+   * - unnamed stores are auto-named `store_N`; name collisions get `#N`
+   */
+  registerStore(store: object, name?: string): void {
+    let storeName = name ?? `store_${String(this.storeIdCounter++)}`;
+    if (this.storeNames.has(storeName)) {
+      let n = 2;
+      while (this.storeNames.has(`${storeName}#${String(n)}`)) n++;
+      storeName = `${storeName}#${String(n)}`;
+    }
+    this.storeNames.add(storeName);
+
+    const members: string[] = [];
+    for (const [key, value] of Object.entries(store)) {
+      if (!isRefSignal(value) || this.internalSignals.has(value)) continue;
+      const existingId = this.signals.get(value);
+      const existingEntry =
+        existingId !== undefined
+          ? this.signalEntries.get(existingId)
+          : undefined;
+
+      if (existingEntry?.name) {
+        // Explicit debug name wins — tag membership only.
+        existingEntry.store = storeName;
+        members.push(existingEntry.id);
+        continue;
+      }
+
+      // Anonymous (or somehow unregistered) — adopt the derived name.
+      const id = `${storeName}.${key}`;
+      if (existingId !== undefined) this.signalEntries.delete(existingId);
+      this.signals.set(value, id);
+      this.signalsByName.set(id, value);
+      this.signalEntries.set(id, {
+        id,
+        name: id,
+        store: storeName,
+        signal: value,
+      });
+      members.push(id);
+    }
+
+    this.emit({
+      kind: 'store:register',
+      store: storeName,
+      members,
+      t: Date.now(),
+    });
   }
 
   trackUpdate<T>(signal: RefSignal<T>, oldValue: T, newValue: T): void {
@@ -454,6 +515,8 @@ class RefSignalDevTools implements DevToolsAdapter {
     this.pulses.clear();
     this.broadcastChannels.clear();
     this.signalIdCounter = 0;
+    this.storeNames.clear();
+    this.storeIdCounter = 0;
   }
 }
 

--- a/src/devtools/overlay/panels/SignalsPanel.tsx
+++ b/src/devtools/overlay/panels/SignalsPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { Fragment, useMemo, useState, type ReactElement } from 'react';
 import { listenersMap } from '../../../refsignal';
 import { devtools, type SignalEntry } from '../../adapter';
 import { formatValue, typeOf } from '../format';
@@ -18,12 +18,63 @@ const RENDER_CAP = 200;
 const subscriberCount = (entry: SignalEntry): number =>
   listenersMap.get(entry.signal as object)?.size ?? 0;
 
+function renderRow(
+  entry: SignalEntry,
+  selectedId: string | null,
+  setSelectedId: (id: string) => void,
+  inGroup: boolean,
+): ReactElement {
+  return (
+    <tr
+      key={entry.id}
+      onClick={() => {
+        setSelectedId(entry.id);
+      }}
+      style={{
+        cursor: 'pointer',
+        background: entry.id === selectedId ? s.colors.bgAlt : undefined,
+      }}
+    >
+      <td style={{ ...s.td, paddingLeft: inGroup ? 16 : undefined }}>
+        {inGroup && entry.store !== undefined
+          ? entry.id.startsWith(`${entry.store}.`)
+            ? entry.id.slice(entry.store.length + 1)
+            : entry.id
+          : entry.id}
+        {!entry.name && (
+          <span
+            style={{
+              color: s.colors.textMuted,
+              marginLeft: 4,
+              fontSize: 10,
+            }}
+          >
+            (anon)
+          </span>
+        )}
+      </td>
+      <td style={{ ...s.td, color: s.colors.textMuted }}>
+        {typeOf(entry.signal.current)}
+      </td>
+      <td style={s.tdMono}>{formatValue(entry.signal.current)}</td>
+      <td style={s.td}>{subscriberCount(entry)}</td>
+      <td style={{ ...s.td, color: s.colors.textMuted }}>
+        {entry.signal.lastUpdated}
+      </td>
+    </tr>
+  );
+}
+
 export function SignalsPanel() {
   useDevtoolsRender();
   const [sortKey, setSortKey] = useState<SortKey>('updated');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   const [filter, setFilter] = useState('');
   const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const [collapsedStores, setCollapsedStores] = useState<Set<string>>(
+    () => new Set(),
+  );
 
   const rows = devtools.getAllSignals();
   const filtered = useMemo(() => {
@@ -32,7 +83,8 @@ export function SignalsPanel() {
       ? rows.filter(
           (r) =>
             r.id.toLowerCase().includes(f) ||
-            (r.name?.toLowerCase().includes(f) ?? false),
+            (r.name?.toLowerCase().includes(f) ?? false) ||
+            (r.store?.toLowerCase().includes(f) ?? false),
         )
       : rows.slice();
     items.sort((a, b) => {
@@ -57,6 +109,35 @@ export function SignalsPanel() {
 
   const visible = filtered.slice(0, RENDER_CAP);
   const truncated = filtered.length > RENDER_CAP;
+
+  // Partition the visible rows into store groups (ordered by store name) and
+  // loose signals. The sort applies *within* each section.
+  const { storeGroups, loose } = useMemo(() => {
+    const byStore = new Map<string, SignalEntry[]>();
+    const rest: SignalEntry[] = [];
+    for (const e of visible) {
+      if (e.store !== undefined) {
+        const arr = byStore.get(e.store) ?? [];
+        arr.push(e);
+        byStore.set(e.store, arr);
+      } else {
+        rest.push(e);
+      }
+    }
+    const groups = Array.from(byStore.entries()).sort(([a], [b]) =>
+      a.localeCompare(b),
+    );
+    return { storeGroups: groups, loose: rest };
+  }, [visible]);
+
+  const toggleStore = (storeName: string): void => {
+    setCollapsedStores((prev) => {
+      const next = new Set(prev);
+      if (next.has(storeName)) next.delete(storeName);
+      else next.add(storeName);
+      return next;
+    });
+  };
 
   const selected = selectedId
     ? (filtered.find((r) => r.id === selectedId) ??
@@ -135,48 +216,61 @@ export function SignalsPanel() {
             </tr>
           </thead>
           <tbody>
-            {visible.map((entry) => (
-              <tr
-                key={entry.id}
-                onClick={() => {
-                  setSelectedId(entry.id);
-                }}
-                style={{
-                  cursor: 'pointer',
-                  background:
-                    entry.id === selectedId ? s.colors.bgAlt : undefined,
-                }}
-              >
-                <td style={s.td}>
-                  {entry.id}
-                  {!entry.name && (
-                    <span
+            {storeGroups.map(([storeName, members]) => {
+              const isCollapsed = collapsedStores.has(storeName);
+              return (
+                <Fragment key={`store:${storeName}`}>
+                  <tr
+                    onClick={() => {
+                      toggleStore(storeName);
+                    }}
+                    style={{ cursor: 'pointer' }}
+                    data-testid={`store-group-${storeName}`}
+                  >
+                    <td
+                      colSpan={5}
                       style={{
-                        color: s.colors.textMuted,
-                        marginLeft: 4,
-                        fontSize: 10,
+                        ...s.td,
+                        background: s.colors.bgAlt,
+                        fontWeight: 600,
                       }}
                     >
-                      (anon)
-                    </span>
-                  )}
-                </td>
-                <td style={{ ...s.td, color: s.colors.textMuted }}>
-                  {typeOf(entry.signal.current)}
-                </td>
-                <td style={s.tdMono}>{formatValue(entry.signal.current)}</td>
-                <td style={s.td}>{subscriberCount(entry)}</td>
-                <td style={{ ...s.td, color: s.colors.textMuted }}>
-                  {entry.signal.lastUpdated}
-                </td>
-              </tr>
-            ))}
+                      {isCollapsed ? '▸' : '▾'} {storeName}
+                      <span
+                        style={{
+                          color: s.colors.textMuted,
+                          marginLeft: 4,
+                          fontSize: 10,
+                          fontWeight: 400,
+                        }}
+                      >
+                        ({members.length} signal
+                        {members.length === 1 ? '' : 's'})
+                      </span>
+                    </td>
+                  </tr>
+                  {!isCollapsed &&
+                    members.map((entry) =>
+                      renderRow(entry, selectedId, setSelectedId, true),
+                    )}
+                </Fragment>
+              );
+            })}
+            {loose.map((entry) =>
+              renderRow(entry, selectedId, setSelectedId, false),
+            )}
           </tbody>
         </table>
       </div>
       {selected && (
         <div style={{ ...s.card, width: 320, alignSelf: 'flex-start' }}>
           <div style={s.cardTitle}>{selected.id}</div>
+          {selected.store !== undefined && (
+            <div style={s.cardRow}>
+              <span style={s.cardLabel}>Store</span>
+              <span>{selected.store}</span>
+            </div>
+          )}
           <div style={s.cardRow}>
             <span style={s.cardLabel}>Type</span>
             <span>{typeOf(selected.signal.current)}</span>

--- a/src/devtools/overlay/panels/panels.test.tsx
+++ b/src/devtools/overlay/panels/panels.test.tsx
@@ -403,6 +403,75 @@ describe('SignalsPanel', () => {
     expect(screen.getByText(/\(anon\)/)).toBeTruthy();
   });
 
+  it('groups store members under a collapsible header', () => {
+    const score = createRefSignal(0);
+    const level = createRefSignal(1);
+    devtools.registerStore({ score, level }, 'game');
+    createRefSignal(9, 'loose');
+    render(<SignalsPanel />);
+
+    // Group header with member count; member rows show the short key.
+    const header = screen.getByTestId('store-group-game');
+    expect(within(header).getByText(/game/)).toBeTruthy();
+    expect(within(header).getByText(/2 signals/)).toBeTruthy();
+    expect(screen.getByText('score')).toBeTruthy();
+    expect(screen.getByText('level')).toBeTruthy();
+    expect(screen.getByText('loose')).toBeTruthy();
+
+    // Collapse hides member rows, loose signals stay.
+    act(() => {
+      fireEvent.click(header);
+    });
+    expect(screen.queryByText('score')).toBeNull();
+    expect(screen.queryByText('level')).toBeNull();
+    expect(screen.getByText('loose')).toBeTruthy();
+
+    // Expand brings them back.
+    act(() => {
+      fireEvent.click(screen.getByTestId('store-group-game'));
+    });
+    expect(screen.getByText('score')).toBeTruthy();
+  });
+
+  it('orders multiple store groups by name and shows full ids for explicitly named members', () => {
+    const xp = createRefSignal(0);
+    const hp = createRefSignal(100, 'vitals'); // explicit name — kept, not renamed
+    devtools.registerStore({ xp }, 'zeta');
+    devtools.registerStore({ hp }, 'alpha');
+    render(<SignalsPanel />);
+
+    const headers = screen.getAllByTestId(/store-group-/);
+    expect(headers[0].getAttribute('data-testid')).toBe('store-group-alpha');
+    expect(headers[1].getAttribute('data-testid')).toBe('store-group-zeta');
+    // Explicitly named member keeps its full name in the row (no store prefix to strip).
+    expect(screen.getByText('vitals')).toBeTruthy();
+  });
+
+  it('shows the store name in the detail card', () => {
+    const score = createRefSignal(0);
+    devtools.registerStore({ score }, 'game');
+    render(<SignalsPanel />);
+    act(() => {
+      fireEvent.click(screen.getByText('score'));
+    });
+    expect(screen.getByText('Store')).toBeTruthy();
+    expect(screen.getByText('game.score')).toBeTruthy(); // card title = full id
+  });
+
+  it('filter matches store names', () => {
+    const score = createRefSignal(0);
+    devtools.registerStore({ score }, 'game');
+    createRefSignal(1, 'unrelated');
+    render(<SignalsPanel />);
+    act(() => {
+      fireEvent.change(screen.getByPlaceholderText(/filter by name/i), {
+        target: { value: 'game' },
+      });
+    });
+    expect(screen.getByText('score')).toBeTruthy();
+    expect(screen.queryByText('unrelated')).toBeNull();
+  });
+
   it('opens a detail card when a row is clicked', () => {
     createRefSignal(100, 'clicky');
     render(<SignalsPanel />);

--- a/src/refsignal.ts
+++ b/src/refsignal.ts
@@ -35,6 +35,14 @@ export interface DevToolsAdapter {
   /** Generic bus channel — subsystems push typed events for their panels. */
   emit(event: DevToolsEvent): void;
   /**
+   * Optional: called by `createRefSignalStore` after the factory runs — the
+   * one place that knows a group of signals is one store. All policy lives
+   * adapter-side: walking the members, deriving names for anonymous signals
+   * (`game.score`), auto-naming unnamed stores, collision handling, grouping.
+   * Custom adapters can omit it.
+   */
+  registerStore?(store: object, debugName?: string): void;
+  /**
    * Called when a signal is touched via `notify()` / `notifyUpdate()` (the
    * direct-mutation hot path, distinct from `.update()` which carries
    * old → new diff via `trackUpdate`). Adapter typically throttles these

--- a/src/store/createRefSignalStore.test.tsx
+++ b/src/store/createRefSignalStore.test.tsx
@@ -7,6 +7,7 @@ import { renderHook } from '../test-utils/renderHook';
 import {
   createRefSignal,
   createComputedRefSignal,
+  setDevToolsAdapter,
   watch,
   type RefSignal,
   type ReadonlyRefSignal,
@@ -102,6 +103,45 @@ describe('createRefSignalStore', () => {
     const b = createRefSignalStore(makeStore);
     a.score.update(10);
     expect(b.score.current).toBe(0);
+  });
+
+  it('reports the store to the devtools adapter with its debug name', () => {
+    const registerStore = jest.fn();
+    const adapter = {
+      trackUpdate: jest.fn(),
+      registerSignal: jest.fn(),
+      getSignalName: jest.fn(),
+      trackEffectStart: jest.fn(),
+      trackEffectEnd: jest.fn(),
+      trackNotify: jest.fn(),
+      emit: jest.fn(),
+      registerStore,
+    };
+    setDevToolsAdapter(adapter);
+    try {
+      const store = createRefSignalStore(makeStore, 'game');
+      expect(registerStore).toHaveBeenCalledWith(store, 'game');
+    } finally {
+      setDevToolsAdapter(null);
+    }
+  });
+
+  it('works with an adapter that lacks the optional registerStore', () => {
+    const adapter = {
+      trackUpdate: jest.fn(),
+      registerSignal: jest.fn(),
+      getSignalName: jest.fn(),
+      trackEffectStart: jest.fn(),
+      trackEffectEnd: jest.fn(),
+      trackNotify: jest.fn(),
+      emit: jest.fn(),
+    };
+    setDevToolsAdapter(adapter);
+    try {
+      expect(() => createRefSignalStore(makeStore, 'game')).not.toThrow();
+    } finally {
+      setDevToolsAdapter(null);
+    }
   });
 });
 

--- a/src/store/createRefSignalStore.ts
+++ b/src/store/createRefSignalStore.ts
@@ -1,3 +1,5 @@
+import { getDevToolsAdapter } from '../refsignal';
+
 /**
  * Creates a module-scope signal store singleton.
  *
@@ -6,6 +8,12 @@
  * Calls `factory()` once immediately — the returned store lives for the
  * application's lifetime. Use {@link useRefSignalStore} to connect the store
  * to React components with opt-in re-renders, timing, and value unwrapping.
+ *
+ * When DevTools are active, the store registers itself with `debugName`: the
+ * Signals panel groups its members under the store, and anonymous member
+ * signals get derived names (`game.score` instead of `signal_3`). Without a
+ * `debugName` the store is auto-named (`store_1`). No-op in production or
+ * when DevTools aren't imported.
  *
  * Signals in the store are accessible directly outside React — no Provider,
  * no hook required for imperative reads and writes.
@@ -22,7 +30,7 @@
  * const gameStore = createRefSignalStore(() => ({
  *   score: createRefSignal(0),
  *   level: createRefSignal(1),
- * }));
+ * }), 'game'); // ← optional debug name — groups members in DevTools
  *
  * // Outside React — direct access
  * gameStore.score.update(42);
@@ -43,6 +51,9 @@
  */
 export function createRefSignalStore<TStore extends object>(
   factory: () => TStore,
+  debugName?: string,
 ): TStore {
-  return factory();
+  const store = factory();
+  getDevToolsAdapter()?.registerStore?.(store, debugName);
+  return store;
 }


### PR DESCRIPTION
Settles the `createRefSignalStore` verdict: its body was literally `return factory()` — a name-only wrapper. It now has its one real job: telling devtools that a group of signals is one store, the only place in the API that knows this at creation time.

## Changes

- **Core** — optional `registerStore?(store, debugName?)` on `DevToolsAdapter` (non-breaking for custom adapters). `createRefSignalStore(factory, debugName?)` calls it after the factory runs. No-op in production or without devtools imported.
- **Adapter** — all policy lives adapter-side: anonymous members renamed `game.score` (propagates to timeline, cascade edges, `getSignalByName`, update attribution); explicitly named members keep their name and gain membership; unnamed stores auto-named `store_N`; collisions suffixed `#2`; `store:register` bus event.
- **Signals panel** — collapsible store group headers with member counts, short keys indented beneath, loose signals after; filter matches store names; detail card shows the store.
- **Docs** — api.md signature + behavior, devtools.md Signals panel + custom-adapter note, README example, decision-tree §8.

Backward compatible — existing `createRefSignalStore(factory)` calls unchanged (auto-named `store_1` in devtools). Composes with `persist`/`broadcast` wrappers as before.

## Tests

13 new (8 adapter, 2 core seam, 3 panel). Full suite: 32 suites, 735 passed.