### PR TITLE
fix: wire pointer drag for the canvas renderer in graph demo

### DIFF
--- a/demo/bench/jotai.tsx
+++ b/demo/bench/jotai.tsx
@@ -19,7 +19,7 @@ import {
   useStore as useJotaiStore,
 } from 'jotai';
 import type { PrimitiveAtom } from 'jotai';
-import { canvasStyle, useCanvasScene } from '../canvas-helpers';
+import { canvasStyle, useCanvasDrag, useCanvasScene } from '../canvas-helpers';
 import {
   JOTAI_C,
   bumpRender,
@@ -150,7 +150,7 @@ function JCanvasView({
       for (const u of unsubs) u();
     };
   }, [atoms, store]);
-  const { canvasRef } = useCanvasScene({
+  const { canvasRef, layoutRef } = useCanvasScene({
     w,
     h,
     edges,
@@ -158,7 +158,13 @@ function JCanvasView({
     readPositions,
     dirtyRef,
   });
-  return <canvas ref={canvasRef} style={canvasStyle} />;
+  const drag = useCanvasDrag({
+    canvasRef,
+    layoutRef,
+    readPositions,
+    writeNode: (i, p) => store.set(atoms[i], p),
+  });
+  return <canvas ref={canvasRef} style={canvasStyle} {...drag} />;
 }
 
 export function JGraph({

--- a/demo/bench/mobx.tsx
+++ b/demo/bench/mobx.tsx
@@ -12,7 +12,7 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { autorun, observable, runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
-import { canvasStyle, useCanvasScene } from '../canvas-helpers';
+import { canvasStyle, useCanvasDrag, useCanvasScene } from '../canvas-helpers';
 import {
   MOBX_C,
   bumpRender,
@@ -143,7 +143,7 @@ function MCanvasView({
       dirtyRef.current = true;
     });
   }, [observableNodes]);
-  const { canvasRef } = useCanvasScene({
+  const { canvasRef, layoutRef } = useCanvasScene({
     w,
     h,
     edges,
@@ -151,7 +151,17 @@ function MCanvasView({
     readPositions,
     dirtyRef,
   });
-  return <canvas ref={canvasRef} style={canvasStyle} />;
+  const drag = useCanvasDrag({
+    canvasRef,
+    layoutRef,
+    readPositions,
+    writeNode: (i, p) =>
+      runInAction(() => {
+        observableNodes[i].x = p.x;
+        observableNodes[i].y = p.y;
+      }),
+  });
+  return <canvas ref={canvasRef} style={canvasStyle} {...drag} />;
 }
 
 export function MGraph({

--- a/demo/bench/react-memo.tsx
+++ b/demo/bench/react-memo.tsx
@@ -11,7 +11,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { canvasStyle, useCanvasScene } from '../canvas-helpers';
+import { canvasStyle, useCanvasDrag, useCanvasScene } from '../canvas-helpers';
 import {
   REACT_C,
   bumpRender,
@@ -78,11 +78,13 @@ function RCanvasView({
   edges,
   w,
   h,
+  writeNode,
 }: {
   positions: Pos[];
   edges: Edge[];
   w: number;
   h: number;
+  writeNode: (idx: number, pos: Pos) => void;
 }) {
   bumpRender();
   const posRef = useRef(positions);
@@ -92,7 +94,7 @@ function RCanvasView({
     dirtyRef.current = true;
   }, [positions]);
   const readPositions = useCallback(() => posRef.current, []);
-  const { canvasRef } = useCanvasScene({
+  const { canvasRef, layoutRef } = useCanvasScene({
     w,
     h,
     edges,
@@ -100,7 +102,13 @@ function RCanvasView({
     readPositions,
     dirtyRef,
   });
-  return <canvas ref={canvasRef} style={canvasStyle} />;
+  const drag = useCanvasDrag({
+    canvasRef,
+    layoutRef,
+    readPositions,
+    writeNode,
+  });
+  return <canvas ref={canvasRef} style={canvasStyle} {...drag} />;
 }
 
 export function RGraph({
@@ -178,7 +186,22 @@ export function RGraph({
 
   const r = renderer ?? BENCH.renderer;
   if (r === 'canvas') {
-    return <RCanvasView positions={positions} edges={edges} w={w} h={h} />;
+    return (
+      <RCanvasView
+        positions={positions}
+        edges={edges}
+        w={w}
+        h={h}
+        writeNode={(i, p) =>
+          setPositions((prev) => {
+            const next = [...prev];
+            next[i] = p;
+            posRef.current = next;
+            return next;
+          })
+        }
+      />
+    );
   }
   return (
     <svg ref={svgRef} viewBox={`0 0 ${w} ${h}`} style={svgStyle}>

--- a/demo/bench/refsignal.tsx
+++ b/demo/bench/refsignal.tsx
@@ -16,7 +16,7 @@ import {
   useRefSignalRender,
 } from 'react-refsignal';
 import type { RefSignal } from 'react-refsignal';
-import { canvasStyle, useCanvasScene } from '../canvas-helpers';
+import { canvasStyle, useCanvasDrag, useCanvasScene } from '../canvas-helpers';
 import {
   SIG_C,
   bumpRender,
@@ -148,7 +148,7 @@ function SigCanvasView({
       for (const s of sigs) s.unsubscribe(onChange);
     };
   }, [sigs]);
-  const { canvasRef } = useCanvasScene({
+  const { canvasRef, layoutRef } = useCanvasScene({
     w,
     h,
     edges,
@@ -156,7 +156,13 @@ function SigCanvasView({
     readPositions,
     dirtyRef,
   });
-  return <canvas ref={canvasRef} style={canvasStyle} />;
+  const drag = useCanvasDrag({
+    canvasRef,
+    layoutRef,
+    readPositions,
+    writeNode: (i, p) => sigs[i].update(p),
+  });
+  return <canvas ref={canvasRef} style={canvasStyle} {...drag} />;
 }
 
 export function SigGraph({

--- a/demo/bench/zustand.tsx
+++ b/demo/bench/zustand.tsx
@@ -23,7 +23,7 @@ import React, {
 } from 'react';
 import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
-import { canvasStyle, useCanvasScene } from '../canvas-helpers';
+import { canvasStyle, useCanvasDrag, useCanvasScene } from '../canvas-helpers';
 import {
   ZUS_C,
   bumpRender,
@@ -142,7 +142,7 @@ function ZCanvasView({ edges, w, h }: { edges: Edge[]; w: number; h: number }) {
       dirtyRef.current = true;
     });
   }, [store]);
-  const { canvasRef } = useCanvasScene({
+  const { canvasRef, layoutRef } = useCanvasScene({
     w,
     h,
     edges,
@@ -150,7 +150,18 @@ function ZCanvasView({ edges, w, h }: { edges: Edge[]; w: number; h: number }) {
     readPositions,
     dirtyRef,
   });
-  return <canvas ref={canvasRef} style={canvasStyle} />;
+  const drag = useCanvasDrag({
+    canvasRef,
+    layoutRef,
+    readPositions,
+    writeNode: (i, p) =>
+      store.setState((prev) => {
+        const next = [...prev.positions];
+        next[i] = p;
+        return { positions: next };
+      }),
+  });
+  return <canvas ref={canvasRef} style={canvasStyle} {...drag} />;
 }
 
 export function ZGraph({
@@ -329,7 +340,7 @@ function ZImpCanvasView({
       dirtyRef.current = true;
     });
   }, [store]);
-  const { canvasRef } = useCanvasScene({
+  const { canvasRef, layoutRef } = useCanvasScene({
     w,
     h,
     edges,
@@ -337,7 +348,18 @@ function ZImpCanvasView({
     readPositions,
     dirtyRef,
   });
-  return <canvas ref={canvasRef} style={canvasStyle} />;
+  const drag = useCanvasDrag({
+    canvasRef,
+    layoutRef,
+    readPositions,
+    writeNode: (i, p) =>
+      store.setState((prev) => {
+        const next = [...prev.positions];
+        next[i] = p;
+        return { positions: next };
+      }),
+  });
+  return <canvas ref={canvasRef} style={canvasStyle} {...drag} />;
 }
 
 export function ZImpGraph({

--- a/demo/canvas-helpers.tsx
+++ b/demo/canvas-helpers.tsx
@@ -6,7 +6,7 @@
 // just owns the canvas element, the rAF loop, hit-testing, and the
 // raster primitives that match the SVG node visuals.
 
-import React, { useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 
 export type Pos = { x: number; y: number };
 export type Edge = [number, number];
@@ -259,4 +259,63 @@ export function hitTest(positions: Pos[], p: Pos): number {
     }
   }
   return bestIdx;
+}
+
+// Manual pointer drag for the canvas renderer. The SVG branch wires drag
+// per-<g>; on canvas there are no DOM nodes to hook, so we hit-test against
+// the live positions on pointerdown and forward moves to `writeNode`, which
+// each mode implements against its own store (sig.update / store.set / etc).
+export function useCanvasDrag({
+  canvasRef,
+  layoutRef,
+  readPositions,
+  writeNode,
+}: {
+  canvasRef: React.RefObject<HTMLCanvasElement | null>;
+  layoutRef: React.RefObject<CanvasLayout>;
+  readPositions: () => Pos[];
+  writeNode: (idx: number, pos: Pos) => void;
+}) {
+  const dragIdx = useRef(-1);
+  const offset = useRef({ x: 0, y: 0 });
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLCanvasElement>) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const p = clientToCanvas(canvas, e.clientX, e.clientY, layoutRef.current);
+      const idx = hitTest(readPositions(), p);
+      if (idx < 0) return;
+      const node = readPositions()[idx];
+      offset.current = { x: node.x - p.x, y: node.y - p.y };
+      dragIdx.current = idx;
+      canvas.setPointerCapture(e.pointerId);
+    },
+    [canvasRef, layoutRef, readPositions],
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLCanvasElement>) => {
+      if (dragIdx.current < 0) return;
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const p = clientToCanvas(canvas, e.clientX, e.clientY, layoutRef.current);
+      writeNode(dragIdx.current, {
+        x: p.x + offset.current.x,
+        y: p.y + offset.current.y,
+      });
+    },
+    [canvasRef, layoutRef, writeNode],
+  );
+
+  const onPointerUp = useCallback(
+    (e: React.PointerEvent<HTMLCanvasElement>) => {
+      if (dragIdx.current < 0) return;
+      dragIdx.current = -1;
+      canvasRef.current?.releasePointerCapture(e.pointerId);
+    },
+    [canvasRef],
+  );
+
+  return { onPointerDown, onPointerMove, onPointerUp };
 }


### PR DESCRIPTION
## Problem

On the `#canvas` route of the graph benchmark demo, nodes were static — dragging did nothing **regardless of the chosen lib**.

The canvas branch of every bench lib (`SigCanvasView`, `JCanvasView`, `ZCanvasView`, `ZImpCanvasView`, `MCanvasView`, `RCanvasView`) rendered a bare `<canvas>` with no pointer handlers. The SVG branch wires drag per-`<g>` element, but canvas has no DOM nodes to hook — so `clientToCanvas`, `hitTest`, and the `layoutRef` returned by `useCanvasScene` were exported but never used anywhere.

## Fix

- Add a shared `useCanvasDrag` hook in `canvas-helpers.tsx`: hit-tests against live positions on `pointerdown`, captures the pointer, and forwards moves to a `writeNode(idx, pos)` callback. This finally wires up the previously-dead `clientToCanvas`/`hitTest`/`layoutRef`.
- Wire it into each lib's canvas view, with a store-specific `writeNode` mirroring that lib's SVG drag path:
  - refsignal → `sigs[i].update(p)`
  - jotai → `store.set(atoms[i], p)`
  - zustand (both stores) → `store.setState` with copied `positions`
  - mobx → `runInAction` mutating `observableNodes[i].x/y`
  - react-memo → `setPositions` (threaded via a new `writeNode` prop)

## Verification

`tsc --noEmit -p demo/tsconfig.json` passes clean.