### PR TITLE
feat(persist): structured-clone mode for native Blob/Date/Map on IndexedDB

### DIFF
--- a/docs/decision-tree.md
+++ b/docs/decision-tree.md
@@ -223,6 +223,7 @@ flowchart TD
     Q3 -->|Default| D["localStorage"]
     Q3 -->|Tab session only| E["storage: 'session'"]
     Q3 -->|"Large data / beyond localStorage limits"| F["storage: 'indexeddb'\nOptions: dbName, dbVersion, storeName"]
+    Q3 -->|"Binary / rich values (Blob, ArrayBuffer, Date, Map, Set)"| Fs["storage: 'indexeddb', structured: true\nNative structured clone — no base64/JSON\nOpt-in, not backward-compatible with an existing key"]
     Q3 -->|Custom backend| G["Implement PersistStorage\n{ get, set, remove } returning Promise"]
 
     A & B & C --> Q4{"Data shape may change across releases?"}

--- a/docs/persist.md
+++ b/docs/persist.md
@@ -14,6 +14,7 @@ Persist signal values across page loads using any async storage backend — `loc
 - [Storage backends](#storage-backends)
   - [localStorage and sessionStorage](#localstorage-and-sessionstorage)
   - [IndexedDB](#indexeddb)
+    - [Structured mode (Blobs and rich values)](#structured-mode-blobs-and-rich-values)
   - [Custom adapter](#custom-adapter)
 - [Versioning and migration](#versioning-and-migration)
 - [Hydration timing](#hydration-timing)
@@ -226,7 +227,7 @@ import { localStorageAdapter, sessionStorageAdapter } from 'react-refsignal/pers
 IndexedDB is the right backend when you need:
 - More than ~5 MB of storage
 - Storage that does not block the main thread on reads
-- A non-string value store (values are serialized strings internally, but the async API avoids I/O contention)
+- To store **binary or rich values natively** — `Blob`, `ArrayBuffer`, typed arrays, `Date`, `Map`, `Set` — without base64/JSON (see [Structured mode](#structured-mode-blobs-and-rich-values) below)
 
 **Inline shorthand** — the common case, one store per app:
 
@@ -257,6 +258,33 @@ Both `persist` calls share the same database connection. Each uses its own stora
 
 The database is opened lazily on first read or write. If `indexedDB` is unavailable, operations fail silently (writes are swallowed, reads return `null`, signals keep their defaults).
 
+#### Structured mode (Blobs and rich values)
+
+By default persist runs every value through `JSON.stringify` before writing — so a `Blob` must be base64-encoded first (~33% storage and memory overhead), and a `Date` or `Map` survives only if you hand-convert it in `serialize`/`deserialize`.
+
+IndexedDB already stores values via the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), which handles `Blob`, `ArrayBuffer`, typed arrays, `Date`, `Map`, `Set`, and nested combinations of them. Opt in with `structured: true` and persist **skips serialization entirely**, handing the value straight to the backend:
+
+```ts
+import { createRefSignal } from 'react-refsignal';
+
+// A voice note stored as a real Blob — no base64, no JSON.
+const attachment = createRefSignal<Blob | null>(null, {
+  persist: { key: 'attachment', storage: 'indexeddb', structured: true },
+});
+
+attachment.update(await recorder.getBlob()); // persisted as-is
+// After reload, `attachment.current` hydrates back as a live Blob.
+```
+
+Also available on the factory form: `indexedDBStorage({ structured: true })`.
+
+**Notes and limits:**
+
+- **Opt-in and not backward-compatible with an existing key.** Values written in string mode cannot be read in structured mode and vice-versa — a key switched to `structured` reads its old data as corrupt and discards it. Use a fresh `key` (or bump `dbVersion`) when migrating.
+- **String backends can't use it.** `structured` only applies to IndexedDB (or a custom adapter that stores non-string values). Passing it with `localStorage`/`sessionStorage` is a no-op and warns in development.
+- **`serialize`/`deserialize` are ignored** in structured mode — the platform does the cloning. Passing them warns in development.
+- **Whole-value rewrite still applies.** Structured clone removes the base64 tax, not the cost of re-cloning the *entire* value on each update. A `RefSignal<Map<string, Blob>>` re-writes every entry when any one changes — great for a small, bounded, low-churn map; for a growing set of blobs prefer one persisted signal per entry (`createRefSignal({ persist: { key: \`blob:${id}\` } })`), where decomposition *is* per-entry persistence.
+
 ### Custom adapter
 
 Any object implementing `PersistStorage` works as a backend — OPFS, SQLite over WASM, a remote API, an in-memory store for tests:
@@ -273,7 +301,7 @@ const myAdapter: PersistStorage = {
 persist(factory, { key: 'game', storage: myAdapter });
 ```
 
-The interface is intentionally minimal — three async methods, string keys, string values (the serialized envelope).
+The interface is intentionally minimal — three async methods, string keys, string values (the serialized envelope). An adapter that stores richer values (an OPFS/IndexedDB-backed store that can hold `Blob`s) may declare itself structured with a `structured: true` marker (`PersistStorage<unknown>`); persist then hands it the envelope object untouched instead of a JSON string — see [Structured mode](#structured-mode-blobs-and-rich-values).
 
 ---
 
@@ -497,6 +525,7 @@ Options for the `persist` field on `createRefSignal` / `useRefSignal`.
 | `dbName` | `string` | `'refsignal'` | `'indexeddb'` only. Database name (`IDBFactory.open` param). |
 | `dbVersion` | `number` | `1` | `'indexeddb'` only. Database schema version (`IDBFactory.open` param). |
 | `storeName` | `string` | `'persist'` | `'indexeddb'` only. Object store name. |
+| `structured` | `boolean` | `false` | `'indexeddb'` only. Store values via structured clone (native `Blob`/`ArrayBuffer`/`Date`/`Map`/`Set`) instead of JSON. Skips `serialize`/`deserialize`. Opt-in, not backward-compatible with an existing key. See [Structured mode](#structured-mode-blobs-and-rich-values). |
 | `version` | `number` | `1` | Schema version stored in the envelope. Triggers `migrate` when it differs from the stored value. |
 | `migrate` | `(stored: unknown, fromVersion: number) => unknown` | — | Transform stored data when the version changes. Return the migrated value, or `null`/`undefined` to discard storage and keep the declared default. |
 | `serialize` | `(value: unknown) => string` | `JSON.stringify` | Serialize the envelope to a string before writing. |
@@ -564,10 +593,10 @@ Hook variant. Sets up persist inside a React Provider; tears down subscriptions 
 ```ts
 import { indexedDBStorage } from 'react-refsignal/persist';
 
-function indexedDBStorage(options?: IDBStorageOptions): PersistStorage
+function indexedDBStorage(options?: IDBStorageOptions): PersistStorage<unknown>
 ```
 
-Creates a `PersistStorage` adapter backed by IndexedDB. The database is opened lazily on first access.
+Creates a `PersistStorage` adapter backed by IndexedDB. The database is opened lazily on first access. With `{ structured: true }` the returned adapter stores values via structured clone (see [Structured mode](#structured-mode-blobs-and-rich-values)).
 
 ### `IDBStorageOptions`
 
@@ -576,16 +605,19 @@ Creates a `PersistStorage` adapter backed by IndexedDB. The database is opened l
 | `dbName` | `Parameters<IDBFactory['open']>[0]` | `'refsignal'` | Database name. |
 | `dbVersion` | `Parameters<IDBFactory['open']>[1]` | `1` | Database schema version. |
 | `storeName` | `string` | `'persist'` | Object store name. |
+| `structured` | `boolean` | `false` | Store values via structured clone (native `Blob`/`ArrayBuffer`/`Date`/`Map`/`Set`) instead of JSON. See [Structured mode](#structured-mode-blobs-and-rich-values). |
 
 ### `PersistStorage`
 
-The interface every storage adapter implements.
+The interface every storage adapter implements. The value type defaults to `string`; a structured adapter is `PersistStorage<unknown>` and sets the optional `structured` marker so persist skips serialization.
 
 ```ts
-interface PersistStorage {
-  get(key: string): Promise<string | null>;
-  set(key: string, value: string): Promise<void>;
+interface PersistStorage<V = string> {
+  get(key: string): Promise<V | null>;
+  set(key: string, value: V): Promise<void>;
   remove(key: string): Promise<void>;
+  /** When true, persist stores values untouched (structured clone). */
+  readonly structured?: boolean;
 }
 ```
 

--- a/src/persist/idb.ts
+++ b/src/persist/idb.ts
@@ -9,6 +9,16 @@ export interface IDBStorageOptions {
   dbVersion?: OpenParams[1];
   /** Object store name used to hold persisted values. Default: `'persist'`. */
   storeName?: string;
+  /**
+   * Store values via IndexedDB's native structured clone instead of
+   * `JSON.stringify` — lets a signal hold a `Blob`/`ArrayBuffer`/`TypedArray`/
+   * `Date`/`Map`/`Set` with no base64/JSON round-trip. Skips `serialize`/
+   * `deserialize`. Default: `false`.
+   *
+   * Opt-in and not backward-compatible per key: a key switched to/from
+   * structured reads its old data as corrupt. Use a fresh key or bump `dbVersion`.
+   */
+  structured?: boolean;
 }
 
 /**
@@ -28,8 +38,18 @@ export interface IDBStorageOptions {
  * const idb = indexedDBStorage({ dbName: 'myApp', storeName: 'cache' });
  * persist(factoryA, { key: 'a', storage: idb });
  * persist(factoryB, { key: 'b', storage: idb });
+ *
+ * @example
+ * // Structured mode — store a Blob natively (no base64/JSON round-trip)
+ * const attachment = createRefSignal<Blob | null>(null, {
+ *   persist: { key: 'attachment', storage: 'indexeddb', structured: true },
+ * });
  */
-export function indexedDBStorage(options?: IDBStorageOptions): PersistStorage {
+export function indexedDBStorage(
+  options?: IDBStorageOptions,
+): PersistStorage<unknown> {
+  const structured = options?.structured ?? false;
+
   // SSR guard — IndexedDB is browser-only; return a no-op adapter that lets
   // hydration resolve immediately with no stored data.
   if (typeof indexedDB === 'undefined') {
@@ -37,6 +57,7 @@ export function indexedDBStorage(options?: IDBStorageOptions): PersistStorage {
       get: () => Promise.resolve(null),
       set: () => Promise.resolve(),
       remove: () => Promise.resolve(),
+      structured,
     };
   }
 
@@ -97,7 +118,7 @@ export function indexedDBStorage(options?: IDBStorageOptions): PersistStorage {
   return {
     get: (key) =>
       tx('readonly', (store) => store.get(key)).then((v) =>
-        v == null ? null : (v as string),
+        v == null ? null : v,
       ),
 
     set: (key, value) =>
@@ -105,5 +126,7 @@ export function indexedDBStorage(options?: IDBStorageOptions): PersistStorage {
 
     remove: (key) =>
       tx('readwrite', (store) => store.delete(key)).then(() => undefined),
+
+    structured,
   };
 }

--- a/src/persist/persist.ts
+++ b/src/persist/persist.ts
@@ -12,9 +12,26 @@ import type { StoreSnapshot } from '../store/useRefSignalStore';
 import { resolveStorage } from './storage';
 import { applyTimingOptions, type TimingOptions } from '../timing';
 
+const IS_PROD =
+  typeof process !== 'undefined' && process.env.NODE_ENV === 'production';
+
 // ─── Stored envelope ──────────────────────────────────────────────────────────
 
 type Envelope = { v: number; data: unknown };
+
+/** Structured backends bypass serialization, so a custom codec is dead config. */
+function warnStructuredCodecIgnored(options: {
+  serialize?: unknown;
+  deserialize?: unknown;
+}): void {
+  if (IS_PROD) return;
+  if (options.serialize !== undefined || options.deserialize !== undefined) {
+    console.warn(
+      '[refsignal] `serialize`/`deserialize` are ignored with a structured storage backend — ' +
+        'values are stored via structured clone, not JSON. Remove the custom codec or drop `structured`.',
+    );
+  }
+}
 
 /**
  * Structural guard for deserialized payloads. Any storage value that does not
@@ -50,6 +67,8 @@ function setupSignalPersist(
   } = options;
 
   const storage = resolveStorage(options);
+  const structured = storage.structured === true;
+  if (structured) warnStructuredCodecIgnored(options);
 
   // ── Hydrate ────────────────────────────────────────────────────────────────
 
@@ -62,7 +81,8 @@ function setupSignalPersist(
   void storage.get(key).then((raw) => {
     if (raw !== null && signal.lastUpdated === counterAtSetup) {
       try {
-        const envelope: unknown = deserialize(raw);
+        // Structured backends hand back the envelope object as-is.
+        const envelope: unknown = structured ? raw : deserialize(raw as string);
         if (!isEnvelope(envelope)) throw new Error('corrupt');
         if (migrate && envelope.v !== version) {
           const migrated = migrate(envelope.data, envelope.v);
@@ -92,14 +112,10 @@ function setupSignalPersist(
 
   const save = () => {
     if (filter && !filter()) return;
-    storage
-      .set(
-        key,
-        serialize({ v: version, data: signal.current } satisfies Envelope),
-      )
-      .catch(() => {
-        // write failed — silently skip
-      });
+    const envelope: Envelope = { v: version, data: signal.current };
+    storage.set(key, structured ? envelope : serialize(envelope)).catch(() => {
+      // write failed — silently skip
+    });
     getDevToolsAdapter()?.emit({
       kind: 'persist:write',
       key,
@@ -140,6 +156,8 @@ export function setupPersist<TStore extends object>(
   } = options;
 
   const storage = resolveStorage(options);
+  const structured = storage.structured === true;
+  if (structured) warnStructuredCodecIgnored(options);
 
   const signalKeys = (
     keys ?? (Object.keys(store) as Array<keyof TStore>)
@@ -158,7 +176,7 @@ export function setupPersist<TStore extends object>(
   void storage.get(key).then((raw) => {
     if (raw !== null) {
       try {
-        const envelope: unknown = deserialize(raw);
+        const envelope: unknown = structured ? raw : deserialize(raw as string);
         if (!isEnvelope(envelope)) throw new Error('corrupt');
         if (typeof envelope.data !== 'object' || envelope.data === null) {
           throw new Error('corrupt');
@@ -230,21 +248,21 @@ export function setupPersist<TStore extends object>(
   // manual `flush()` calls are user intent and should write as asked. If a
   // caller flushes mid-`await clear()`, the clear's final `storage.remove`
   // still lands after, leaving storage empty as expected.
+  const encode = (data: Record<string, unknown>): unknown => {
+    const envelope: Envelope = { v: version, data };
+    return structured ? envelope : serialize(envelope);
+  };
+
   const doFlush = (): Promise<void> =>
-    storage.set(
-      key,
-      serialize({ v: version, data: buildSnapshot() } satisfies Envelope),
-    );
+    storage.set(key, encode(buildSnapshot()));
 
   const save = () => {
     if (suppressed) return;
     const snapshot = buildSnapshot();
     if (filter && !filter(snapshot as StoreSnapshot<TStore>)) return;
-    storage
-      .set(key, serialize({ v: version, data: snapshot } satisfies Envelope))
-      .catch(() => {
-        // write failed — silently skip
-      });
+    storage.set(key, encode(snapshot)).catch(() => {
+      // write failed — silently skip
+    });
     getDevToolsAdapter()?.emit({
       kind: 'persist:write',
       key,

--- a/src/persist/storage.ts
+++ b/src/persist/storage.ts
@@ -43,16 +43,31 @@ export const sessionStorageAdapter: PersistStorage = syncStorageAdapter(
   () => window.sessionStorage,
 );
 
-export function resolveStorage(config: StorageConfig): PersistStorage {
-  const { storage } = config as { storage?: unknown };
+const IS_PROD =
+  typeof process !== 'undefined' && process.env.NODE_ENV === 'production';
 
-  if (!storage || storage === 'local') return localStorageAdapter;
-  if (storage === 'session') return sessionStorageAdapter;
+export function resolveStorage(config: StorageConfig): PersistStorage<unknown> {
+  const { storage, structured } = config as {
+    storage?: unknown;
+    structured?: boolean;
+  };
+
+  if (!storage || storage === 'local' || storage === 'session') {
+    if (!IS_PROD && structured) {
+      console.warn(
+        `[refsignal] \`structured: true\` has no effect on ${
+          storage === 'session' ? 'sessionStorage' : 'localStorage'
+        } — string-only backends cannot store binary values. ` +
+          'Use `storage: "indexeddb"` (or a structured custom adapter) for Blob/ArrayBuffer/Date/Map/Set.',
+      );
+    }
+    return storage === 'session' ? sessionStorageAdapter : localStorageAdapter;
+  }
   if (storage === 'indexeddb') {
     const { dbName, dbVersion, storeName } = config as IDBStorageOptions;
-    return indexedDBStorage({ dbName, dbVersion, storeName });
+    return indexedDBStorage({ dbName, dbVersion, storeName, structured });
   }
-  return storage as PersistStorage;
+  return storage as PersistStorage<unknown>;
 }
 
 /**

--- a/src/persist/structured.test.ts
+++ b/src/persist/structured.test.ts
@@ -1,0 +1,201 @@
+/**
+ * @jest-environment node
+ *
+ * Structured-clone persistence (Blob/Date/Map/Set native on IndexedDB).
+ *
+ * `node` env on purpose: fake-indexeddb clones via the global `structuredClone`,
+ * and only Node's native one preserves Blob/Date/Map (the jsdom setup polyfills
+ * it with a Blob-destroying JSON round-trip). `instanceof` is unreliable across
+ * jest realms, so type survival is asserted via `constructor.name` + behavior.
+ */
+import 'fake-indexeddb/auto';
+import { createRefSignal, type RefSignal } from '../refsignal';
+import { indexedDBStorage } from './idb';
+import { setupPersist } from './persist';
+
+/** Drain IndexedDB's multi-tick async (open → txn → request) plus microtasks. */
+const flushIDB = async () => {
+  for (let i = 0; i < 3; i++) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+};
+
+// ─── Adapter marker ────────────────────────────────────────────────────────────
+
+describe('indexedDBStorage({ structured })', () => {
+  it('marks the adapter structured when opted in', () => {
+    expect(indexedDBStorage({ structured: true }).structured).toBe(true);
+  });
+
+  it('is not structured by default', () => {
+    expect(indexedDBStorage().structured).toBeFalsy();
+  });
+
+  it('marks the SSR no-op adapter consistently', () => {
+    const saved = (globalThis as { indexedDB?: unknown }).indexedDB;
+    delete (globalThis as { indexedDB?: unknown }).indexedDB;
+    try {
+      expect(indexedDBStorage({ structured: true }).structured).toBe(true);
+    } finally {
+      (globalThis as { indexedDB?: unknown }).indexedDB = saved;
+    }
+  });
+
+  it('stores structured values untouched (no JSON string) and reads them back', async () => {
+    const idb = indexedDBStorage({
+      dbName: 'struct-adapter',
+      storeName: 's',
+      structured: true,
+    });
+    await idb.set('k', { v: 1, data: { blob: new Blob(['hi']) } });
+    const out = (await idb.get('k')) as { data: { blob: Blob } };
+    expect(out.data.blob.constructor.name).toBe('Blob');
+    expect(await out.data.blob.text()).toBe('hi');
+  });
+});
+
+// ─── Store-level round-trip ─────────────────────────────────────────────────────
+
+describe('structured persist — store-level round-trip', () => {
+  type NoteStore = {
+    attachment: RefSignal<Blob | null>;
+    when: RefSignal<Date>;
+    tags: RefSignal<Map<string, number>>;
+  };
+
+  const makeStore = (): NoteStore => ({
+    attachment: createRefSignal<Blob | null>(null),
+    when: createRefSignal(new Date(0)),
+    tags: createRefSignal(new Map<string, number>()),
+  });
+
+  it('persists and re-hydrates Blob, Date and Map through IndexedDB', async () => {
+    const config = {
+      key: 'note',
+      storage: 'indexeddb' as const,
+      dbName: 'struct-store',
+      storeName: 'p',
+      structured: true,
+    };
+
+    // Write phase — populate a store and let it persist.
+    const a = makeStore();
+    const controllerA = setupPersist(a, config);
+    await flushIDB(); // let hydrate (empty) settle before writing
+
+    a.attachment.update(new Blob(['hello world'], { type: 'text/plain' }));
+    a.when.update(new Date(1000));
+    a.tags.update(new Map([['a', 1]]));
+    await flushIDB();
+    controllerA.cleanup();
+
+    // Read phase — a fresh store hydrates from the same key.
+    const b = makeStore();
+    setupPersist(b, config);
+    await flushIDB();
+
+    expect(b.attachment.current?.constructor.name).toBe('Blob');
+    expect(await b.attachment.current!.text()).toBe('hello world');
+    expect(b.attachment.current!.type).toBe('text/plain');
+    expect(b.when.current.constructor.name).toBe('Date');
+    expect(b.when.current.getTime()).toBe(1000);
+    expect(b.tags.current.constructor.name).toBe('Map');
+    expect(b.tags.current.get('a')).toBe(1);
+  });
+
+  it('writes the envelope object (not a JSON string) to the backend', async () => {
+    const store = { attachment: createRefSignal<Blob | null>(null) };
+    setupPersist(store, {
+      key: 'raw-check',
+      storage: 'indexeddb',
+      dbName: 'struct-raw',
+      storeName: 'p',
+      structured: true,
+    });
+    await flushIDB();
+    store.attachment.update(new Blob(['bytes']));
+    await flushIDB();
+
+    // Read the raw stored value with a plain (non-persist) adapter.
+    const raw = await indexedDBStorage({
+      dbName: 'struct-raw',
+      storeName: 'p',
+    }).get('raw-check');
+    expect(typeof raw).not.toBe('string');
+    expect((raw as { v: number }).v).toBe(1);
+    expect(
+      (raw as { data: { attachment: Blob } }).data.attachment.constructor.name,
+    ).toBe('Blob');
+  });
+});
+
+// ─── Signal-level round-trip ─────────────────────────────────────────────────────
+
+describe('structured persist — signal-level', () => {
+  it('re-hydrates a Blob-valued signal from a fresh signal', async () => {
+    const persist = {
+      key: 'sig-blob',
+      storage: 'indexeddb' as const,
+      dbName: 'struct-sig',
+      storeName: 'p',
+      structured: true,
+    };
+
+    const a = createRefSignal<Blob | null>(null, { persist });
+    await flushIDB();
+    a.update(new Blob(['voice'], { type: 'audio/webm' }));
+    await flushIDB();
+
+    const b = createRefSignal<Blob | null>(null, { persist });
+    await flushIDB();
+    expect(b.current?.constructor.name).toBe('Blob');
+    expect(await b.current!.text()).toBe('voice');
+    expect(b.current!.type).toBe('audio/webm');
+  });
+});
+
+// ─── Guards ──────────────────────────────────────────────────────────────────
+
+describe('structured persist — guards', () => {
+  let warn: jest.SpyInstance;
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it('warns when structured is requested on a string backend (localStorage)', () => {
+    const store = { count: createRefSignal(0) };
+    // The resolve-time guard fires before any storage access. Cast past the
+    // type error to exercise the runtime guard a plain-JS caller would hit.
+    setupPersist(store, {
+      key: 'g1',
+      ...({ storage: 'local', structured: true } as { storage: 'local' }),
+    });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('no effect on localStorage'),
+    );
+  });
+
+  it('warns and ignores a custom serialize when the backend is structured', async () => {
+    const serialize = jest.fn((v: unknown) => JSON.stringify(v));
+    const store = { count: createRefSignal(0) };
+    setupPersist(store, {
+      key: 'g2',
+      storage: 'indexeddb',
+      dbName: 'struct-guard',
+      storeName: 'p',
+      structured: true,
+      serialize,
+    });
+    await flushIDB();
+    store.count.update(5);
+    await flushIDB();
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('`serialize`/`deserialize` are ignored'),
+    );
+    expect(serialize).not.toHaveBeenCalled();
+  });
+});

--- a/src/persist/types.ts
+++ b/src/persist/types.ts
@@ -9,17 +9,23 @@ type PersistableKeys<TStore> = {
     : never;
 }[keyof TStore];
 
-export interface PersistStorage {
-  get(key: string): Promise<string | null>;
-  set(key: string, value: string): Promise<void>;
+export interface PersistStorage<V = string> {
+  get(key: string): Promise<V | null>;
+  set(key: string, value: V): Promise<void>;
   remove(key: string): Promise<void>;
+  /** When `true`, persist stores values untouched (structured clone), skipping `serialize`/`deserialize`. Set by `indexedDBStorage({ structured: true })`. */
+  readonly structured?: boolean;
 }
 
 export type PersistStorageShorthand = 'local' | 'session' | 'indexeddb';
 
-/** Discriminated union — IDB-specific options are only valid when `storage: 'indexeddb'`. */
+/**
+ * Discriminated union — IDB-specific options are only valid when `storage: 'indexeddb'`.
+ * `structured` is a type error on string backends; structured custom adapters are `PersistStorage<unknown>`.
+ */
 export type StorageConfig =
-  | { storage?: 'local' | 'session' | PersistStorage }
+  | { storage?: 'local' | 'session' | PersistStorage; structured?: never }
+  | { storage: PersistStorage<unknown>; structured?: never }
   | ({ storage: 'indexeddb' } & IDBStorageOptions);
 
 type PersistCommonOptions = {


### PR DESCRIPTION
Opt in with `structured: true` to persist `Blob`/`ArrayBuffer`/`TypedArray`/`Date`/`Map`/`Set` natively on IndexedDB, skipping the JSON/base64 round-trip.

## Changes
- `PersistStorage<V = string>` — generic value type, default `string` (100% backward-compatible).
- `indexedDBStorage({ structured: true })` and `{ storage: 'indexeddb', structured: true }` shorthand; adapter carries a `structured` marker.
- persist bypasses `serialize`/`deserialize` when the resolved storage is structured.
- Type guard: `structured` is a type error on string backends; dev-warns on misuse (localStorage, or a redundant custom codec).
- Custom adapters opt in via `PersistStorage<unknown>` + `structured: true`.
- Docs: persist.md (Structured mode) + decision-tree §9.

## Tests
`src/persist/structured.test.ts` (node env for native `structuredClone`) — round-trips Blob/Date/Map at signal + store level, guards, marker. Full suite 747 green.